### PR TITLE
feat(competitions): copa participativa com autodeclaracao e geo best-effort

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,6 +74,13 @@ export default defineNuxtConfig({
       process.env.HEMOCIONE_ID_JWT_SECRET_KEY ?? "hemocione",
     secret: process.env.API_SECRET ?? "secret",
     donationsQueueUrl: process.env.DONATIONS_QUEUE_URL ?? "queue-url",
+    ondeDoarApiUrl:
+      process.env.ONDE_DOAR_API_URL ?? "https://ondedoar.hemocione.com.br",
+    // Hosts de onde aceitamos um proofUrl vindo por query string. Comparacao de
+    // host exato — ver utils/proofUrl.ts.
+    allowedProofHosts:
+      process.env.ALLOWED_PROOF_HOSTS ??
+      "possodoar.hemocione.com.br,possodoar.d.hemocione.com.br,cdn.hemocione.com.br",
   },
 
   routeRules: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "utils:reset-db": "npx prisma db push --force-reset && npx prisma db push",
     "utils:populate": "docker cp sql-scripts/populate_tables.sql my-postgres:/populate.sql && docker exec -i my-postgres psql -U postgres -d competitions -f /populate.sql",
     "migrate:deploy": "if [ \"$ENABLE_MIGRATIONS\" = \"1\" ]; then npx prisma migrate deploy; else echo \"no migrations enabled\"; fi",
-    "postinstall": "yarn migrate:deploy && npx prisma generate && nuxt prepare"
+    "postinstall": "yarn migrate:deploy && npx prisma generate && nuxt prepare",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@aws-sdk/client-sqs": "^3.600.0",
@@ -32,7 +34,8 @@
     "nuxt-bugsnag": "^7.2.3",
     "nuxt-vercel-analytics": "^1.0.0",
     "slugify": "^1.6.6",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.10"
   },
   "prisma": {
     "schema": "server/db/schema.prisma"

--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -129,7 +129,10 @@
                   ? "Comprovante da sua participação"
                   : "Comprovante de doação"
               }}
-              <span v-if="competition?.mandatory_proof && !form.proofUrl"
+              <span
+                v-if="
+                  competition?.mandatory_proof && !form.proof && !form.proofUrl
+                "
                 >*</span
               ></label
             >

--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -92,6 +92,26 @@
               </el-option>
             </el-select>
           </div>
+          <!-- Autodeclaracao: so aparece em copa participativa -->
+          <div
+            class="column"
+            key="kind"
+            v-if="isParticipation && isTeamSelected"
+          >
+            <label class="label-form">Você conseguiu doar? <span>*</span></label>
+            <span class="proof-type-text">
+              Vale participar mesmo sem conseguir doar. Se a pré-triagem apontou
+              algum impedimento, sua participação continua contando para a sua
+              unidade.
+            </span>
+            <el-radio-group v-model="form.kind" size="large">
+              <el-radio-button value="donation">Sim, eu doei</el-radio-button>
+              <el-radio-button value="participation">
+                Não consegui doar
+              </el-radio-button>
+            </el-radio-group>
+          </div>
+
           <!-- Proof Field -->
           <div class="column" key="proof" v-if="isTeamSelected">
             <input
@@ -104,8 +124,14 @@
               @change="handleFileSelect($event)"
             />
             <label class="label-form"
-              >Comprovante de doação
-              <span v-if="competition?.mandatory_proof">*</span></label
+              >{{
+                isParticipation
+                  ? "Comprovante da sua participação"
+                  : "Comprovante de doação"
+              }}
+              <span v-if="competition?.mandatory_proof && !form.proofUrl"
+                >*</span
+              ></label
             >
             <span class="proof-type-text">{{ proofText }}</span>
             <Transition name="fade" appear mode="out-in">
@@ -214,6 +240,13 @@ const route = useRoute();
 const slug = route.params.slug;
 const code = route.query.code ? String(route.query.code) : null;
 
+// Quem chega pelo caminho "reprovado na pre-triagem" vem com kind e o
+// comprovante ja na URL. O radio segue editavel: o campo e autodeclarado, entao
+// mentir pelo query param equivale a mentir clicando.
+const initialKind =
+  route.query.kind === "participation" ? "participation" : "donation";
+const externalProofUrl = route.query.proofUrl ? String(route.query.proofUrl) : "";
+
 const uploadingImage = ref(false);
 const registeringDonation = ref(false);
 
@@ -282,24 +315,38 @@ const teamInfluenceControlled = Boolean(
     competition.value?.influence_controls_team
 );
 
+const isParticipationCompetition = competition.value?.mode === "participation";
+
 const presentationText = isCompetitionInFuture
-  ? `${competition.value?.name} ainda não começou. Aguarde até a data de início (${initialDate}) para registrar sua doação.`
+  ? `${competition.value?.name} ainda não começou. Aguarde até a data de início (${initialDate}) para registrar sua ${
+      isParticipationCompetition ? "participação" : "doação"
+    }.`
   : isCompetitionInPast
   ? "A copa já acabou. Obrigado por participar!"
   : teamInfluenceControlled
   ? null
+  : isParticipationCompetition
+  ? "Selecione sua unidade para registrar sua participação na campanha."
   : "Selecione sua equipe para registrar sua doação.";
 
 const proofText =
   competition.value?.proof_type === "document"
     ? "Envie uma foto do comprovante de doação de sangue"
+    : competition.value?.proof_type === "any"
+    ? "Envie qualquer registro da sua ida ao banco de sangue: uma selfie no local, foto do comprovante ou da pulseira. Se você não pôde doar, o comprovante da pré-triagem já vale."
     : "Envie uma foto sua realizando a doação de sangue (pode ser uma selfie!)";
 
 export type Competition = typeof competition.value;
 
+const isParticipation = computed(
+  () => competition.value?.mode === "participation",
+);
+
 const form = ref({
   competitionTeamId: null as number | null | undefined,
   proof: "",
+  proofUrl: externalProofUrl,
+  kind: initialKind as "donation" | "participation",
   institutionId: null as number | null | undefined,
   extraFields: {
     ...Object.fromEntries(extraFieldsSlugs.map((slug) => [slug, ""])),
@@ -358,7 +405,11 @@ const canRegisterDonation = computed(() => {
   return (
     isTeamSelected.value &&
     allRequiredExtraFieldsFilled.value &&
-    (!competition.value?.mandatory_proof || form.value.proof)
+    // O comprovante da pre-triagem, recebido por proofUrl, satisfaz a exigencia
+    // de prova: quem foi reprovado nao tem foto de doacao para enviar.
+    (!competition.value?.mandatory_proof ||
+      form.value.proof ||
+      form.value.proofUrl)
   );
 });
 
@@ -372,7 +423,7 @@ const coolButtonText = computed(() => {
   if (!canRegisterDonation.value) {
     return "Preencha os Campos Obrigatórios";
   }
-  return "Registrar Doação";
+  return isParticipation.value ? "Registrar Participação" : "Registrar Doação";
 });
 
 const MB = 1024 * 1024;
@@ -451,6 +502,39 @@ const extraFieldsResponse = computed(() => {
   );
 });
 
+const GEO_TIMEOUT_MS = 8000;
+
+/**
+ * Geolocalizacao best-effort. NUNCA rejeita: geo e enriquecimento de prova, nao
+ * pre-requisito de registro.
+ *
+ * Dentro do app, o iframe precisa de allow="geolocation" e o build nativo
+ * precisa das permissoes de plataforma. Em app antigo isso simplesmente nao vem
+ * — e o registro tem que funcionar do mesmo jeito.
+ */
+async function captureGeo(): Promise<
+  { lat: number; lng: number; accuracy?: number } | { reason: string }
+> {
+  if (!import.meta.client || !navigator.geolocation) {
+    return { reason: "unavailable" };
+  }
+  return new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) =>
+        resolve({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        }),
+      (err) =>
+        resolve({
+          reason: err.code === err.PERMISSION_DENIED ? "denied" : "timeout",
+        }),
+      { timeout: GEO_TIMEOUT_MS, maximumAge: 60_000 },
+    );
+  });
+}
+
 async function handleSubmit(event: any) {
   registeringDonation.value = true;
   event.preventDefault();
@@ -459,9 +543,14 @@ async function handleSubmit(event: any) {
   }
   const influenceId = influencedBy?.value?.id;
 
+  const geo = isParticipation.value ? await captureGeo() : undefined;
+
   const payload = {
     competitionTeamId: form.value.competitionTeamId,
     proof: form.value.proof,
+    proofUrl: form.value.proofUrl || undefined,
+    kind: isParticipation.value ? form.value.kind : "donation",
+    geo,
     extraFields: extraFieldsResponse.value,
     influenceId,
     competitionName: competition.value?.name,

--- a/pages/competition/[slug]/success.vue
+++ b/pages/competition/[slug]/success.vue
@@ -6,7 +6,11 @@
       </header>
       <div class="success">
         <img src="/images/check-donation.svg" alt="checked-icon" />
-        <span
+        <span v-if="competition?.mode === 'participation'">
+          Participação registrada com sucesso! Obrigado por entrar nessa com a
+          gente :)
+        </span>
+        <span v-else
           >Doação registrada com sucesso! Obrigado por salvar 4 vidas :)</span
         >
       </div>

--- a/server/api/v1/competitions/[slug]/donations/index.post.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.post.ts
@@ -1,13 +1,24 @@
 import { useHemocioneUserAuth } from "~/server/services/auth";
 import { getCompetitionBySlug } from "~/server/services/competitionService";
 import { registerDonation } from "~/server/services/donationService";
+import { findNearestBloodBank } from "~/server/services/ondedoar";
 import { callWebhook } from "~/server/services/webhookService";
 import { getPrettyFullName } from "~/utils/getPrettyFullName";
+import { isAllowedProofUrl } from "~/utils/proofUrl";
+import { resolveGeoValidation } from "~/utils/geo";
+import {
+  isValidExtraFieldsResponse,
+  type ExtraFields,
+  type ExtraFieldsResponse,
+} from "~/utils/validateExtraFields";
 import { waitUntil } from '@vercel/functions';
+
+const MAX_GEO_DISTANCE_METERS = 500;
 
 export default defineEventHandler(async (event) => {
   const competitionSlug = String(getRouterParam(event, 'slug'));
   const user = useHemocioneUserAuth(event);
+  const config = useRuntimeConfig();
 
   const competition = await getCompetitionBySlug(competitionSlug);
   if (!competition) {
@@ -30,11 +41,13 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event);
   const {
     proof,
+    proofUrl,
     extraFields,
     competitionTeamId,
-    influenceId
+    influenceId,
+    kind: rawKind,
+    geo,
   } = body;
-
 
   if (!competitionTeamId) {
     throw createError({
@@ -43,7 +56,31 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  if (competition.mandatory_proof && !proof) {
+  const isParticipationCompetition = competition.mode === "participation";
+  const kind: "donation" | "participation" =
+    rawKind === "participation" ? "participation" : "donation";
+
+  if (kind === "participation" && !isParticipationCompetition) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Competition does not accept participation",
+    });
+  }
+
+  // proofUrl chega por query string: e o comprovante da pre-triagem, mandado
+  // pelo can-donate. Sem allowlist o campo proof viraria armazem de link
+  // arbitrario. Fora da allowlist o valor e ignorado, nao falha o registro.
+  const allowedProofHosts = String(config.allowedProofHosts ?? "")
+    .split(",")
+    .map((host) => host.trim())
+    .filter(Boolean);
+  const externalProof = isAllowedProofUrl(proofUrl, allowedProofHosts)
+    ? String(proofUrl)
+    : undefined;
+
+  const resolvedProof = proof || externalProof;
+
+  if (competition.mandatory_proof && !resolvedProof) {
     throw createError({
       statusCode: 400,
       statusMessage: "Bad Request - Missing proof",
@@ -56,15 +93,65 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Bad Request - Competition does not have influence",
     });
   }
-  // TODO: validate extraFields with competition.extraFields
+
+  const configuredExtraFields = (competition.extraFields ??
+    []) as unknown as ExtraFields;
+  if (
+    Array.isArray(configuredExtraFields) &&
+    configuredExtraFields.length &&
+    !isValidExtraFieldsResponse(
+      configuredExtraFields,
+      (extraFields ?? []) as ExtraFieldsResponse,
+    )
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid extraFields",
+    });
+  }
+
+  // Geolocalizacao best-effort: qualquer falha resulta em geoValidated=false,
+  // nunca em registro recusado.
+  let proofMetadata;
+  if (isParticipationCompetition) {
+    const lat = Number(geo?.lat);
+    const lng = Number(geo?.lng);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      const nearest = await findNearestBloodBank(
+        lat,
+        lng,
+        MAX_GEO_DISTANCE_METERS,
+      );
+      proofMetadata = resolveGeoValidation({
+        coords: {
+          lat,
+          lng,
+          accuracy: Number.isFinite(Number(geo?.accuracy))
+            ? Number(geo.accuracy)
+            : undefined,
+        },
+        capturedAt: new Date(),
+        nearest,
+        maxDistanceMeters: MAX_GEO_DISTANCE_METERS,
+      });
+    } else {
+      proofMetadata = resolveGeoValidation({
+        coords: null,
+        reason: geo?.reason,
+      });
+    }
+  }
+
   const payload = {
     user_name: getPrettyFullName(user.givenName, user.surName),
     user_email: user.email,
     hemocioneID: user.id,
     extraFields,
-    proof,
+    proof: resolvedProof,
     influenceId,
     status: competition.autoApprove ? "approved" : "pending",
+    kind,
+    proof_metadata: proofMetadata,
   } as const
 
   const createdDonation = await registerDonation(

--- a/server/api/v1/competitions/[slug]/donations/index.post.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.post.ts
@@ -160,7 +160,14 @@ export default defineEventHandler(async (event) => {
     payload
   );
 
-  if (createdDonation.status === "approved" && competition.webhook_configs?.donation_approved) {
+  // Mesmo gate da fila do hemocione-id: o webhook se chama donation_approved e
+  // seus consumidores esperam uma doacao. Disparar em participacao faria eles
+  // contabilizarem bolsa que nao existe.
+  if (
+    kind === "donation" &&
+    createdDonation.status === "approved" &&
+    competition.webhook_configs?.donation_approved
+  ) {
     waitUntil(callWebhook(competition.webhook_configs.donation_approved, { hemocioneId: user.id }));
   }
 

--- a/server/db/migrations/20260730154008_add_participation_mode/PROD_RUNBOOK.sql
+++ b/server/db/migrations/20260730154008_add_participation_mode/PROD_RUNBOOK.sql
@@ -1,26 +1,57 @@
--- RUNBOOK DE PRODUCAO — aplicar ANTES de `prisma migrate deploy`
+-- RUNBOOK DE PRODUCAO — aplicar via psql ANTES de `prisma migrate deploy`
 --
--- Por que existe: o `migration.sql` cria o indice
--- "donations_competitionId_kind" SEM CONCURRENTLY, porque o Prisma envelopa
--- migrations em transacao e o Postgres recusa CREATE INDEX CONCURRENTLY dentro
--- de transacao (erro 25001). Sem CONCURRENTLY, o CREATE INDEX pega um lock que
--- BLOQUEIA ESCRITA em "donations" durante toda a construcao — inaceitavel numa
--- tabela grande no meio de campanha.
+-- POR QUE EXISTE
+-- O `migration.sql` cria o indice "donations_competitionId_kind" SEM
+-- CONCURRENTLY, porque o Prisma envelopa migrations em transacao e o Postgres
+-- recusa CREATE INDEX CONCURRENTLY dentro de transacao (erro 25001). Sem
+-- CONCURRENTLY, o CREATE INDEX pega lock que BLOQUEIA ESCRITA em "donations"
+-- durante toda a construcao — inaceitavel numa tabela grande no meio de
+-- campanha.
 --
--- Como usar:
---   1. rodar este arquivo via psql, fora de transacao, ANTES do deploy
---   2. depois rodar o `prisma migrate deploy` normalmente
+-- ORDEM IMPORTA
+-- Nao da para criar o indice concorrente antes de a coluna "kind" existir.
+-- Por isso este runbook e AUTOSSUFICIENTE: cria os tipos, as colunas e so
+-- depois o indice concorrente — na ordem certa, tudo idempotente. O
+-- `migration.sql` tambem e idempotente, entao depois disto ele vira no-op
+-- inteiro e o Prisma marca a migration como aplicada sem `migrate resolve`.
 --
--- O `IF NOT EXISTS` no migration.sql torna a criacao do indice no-op depois
--- disso, e a migration e marcada como aplicada sem `migrate resolve` manual.
+-- COMO USAR
+--   1. psql < PROD_RUNBOOK.sql        (este arquivo, fora de transacao)
+--   2. prisma migrate deploy          (no-op para esta migration)
 --
--- Nao envolver em BEGIN/COMMIT: CONCURRENTLY precisa rodar fora de transacao.
+-- NAO envolver em BEGIN/COMMIT: CONCURRENTLY precisa rodar fora de transacao.
 
+-- 1) Tipos. CREATE TYPE nao aceita IF NOT EXISTS, daí o DO block.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'CompetitionMode') THEN
+    CREATE TYPE "CompetitionMode" AS ENUM ('donation', 'participation');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'RegistrationKind') THEN
+    CREATE TYPE "RegistrationKind" AS ENUM ('donation', 'participation');
+  END IF;
+END
+$$;
+
+ALTER TYPE "ProofType" ADD VALUE IF NOT EXISTS 'any';
+
+-- 2) Colunas. ADD COLUMN com DEFAULT e metadata-only a partir do PG 11, entao
+--    nao reescreve a tabela — o lock e curto mesmo numa tabela grande.
+ALTER TABLE "competitions"
+  ADD COLUMN IF NOT EXISTS "mode" "CompetitionMode" NOT NULL DEFAULT 'donation';
+
+ALTER TABLE "donations"
+  ADD COLUMN IF NOT EXISTS "kind" "RegistrationKind" NOT NULL DEFAULT 'donation';
+
+ALTER TABLE "donations"
+  ADD COLUMN IF NOT EXISTS "proof_metadata" JSONB;
+
+-- 3) Indice, agora que a coluna existe. Fora de transacao, sem bloquear escrita.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "donations_competitionId_kind"
   ON "donations" ("competitionId", "kind");
 
--- Conferir que ficou valido (um CONCURRENTLY interrompido deixa indice INVALID,
--- que precisa ser dropado e recriado):
+-- 4) Conferir. Um CONCURRENTLY interrompido deixa indice INVALID, que precisa
+--    ser dropado e recriado:
 --
 --   SELECT i.indisvalid, c.relname
 --   FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid

--- a/server/db/migrations/20260730154008_add_participation_mode/PROD_RUNBOOK.sql
+++ b/server/db/migrations/20260730154008_add_participation_mode/PROD_RUNBOOK.sql
@@ -1,0 +1,27 @@
+-- RUNBOOK DE PRODUCAO — aplicar ANTES de `prisma migrate deploy`
+--
+-- Por que existe: o `migration.sql` cria o indice
+-- "donations_competitionId_kind" SEM CONCURRENTLY, porque o Prisma envelopa
+-- migrations em transacao e o Postgres recusa CREATE INDEX CONCURRENTLY dentro
+-- de transacao (erro 25001). Sem CONCURRENTLY, o CREATE INDEX pega um lock que
+-- BLOQUEIA ESCRITA em "donations" durante toda a construcao — inaceitavel numa
+-- tabela grande no meio de campanha.
+--
+-- Como usar:
+--   1. rodar este arquivo via psql, fora de transacao, ANTES do deploy
+--   2. depois rodar o `prisma migrate deploy` normalmente
+--
+-- O `IF NOT EXISTS` no migration.sql torna a criacao do indice no-op depois
+-- disso, e a migration e marcada como aplicada sem `migrate resolve` manual.
+--
+-- Nao envolver em BEGIN/COMMIT: CONCURRENTLY precisa rodar fora de transacao.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "donations_competitionId_kind"
+  ON "donations" ("competitionId", "kind");
+
+-- Conferir que ficou valido (um CONCURRENTLY interrompido deixa indice INVALID,
+-- que precisa ser dropado e recriado):
+--
+--   SELECT i.indisvalid, c.relname
+--   FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+--   WHERE c.relname = 'donations_competitionId_kind';

--- a/server/db/migrations/20260730154008_add_participation_mode/migration.sql
+++ b/server/db/migrations/20260730154008_add_participation_mode/migration.sql
@@ -24,4 +24,13 @@ ALTER TABLE "donations" ADD COLUMN     "kind" "RegistrationKind" NOT NULL DEFAUL
 ADD COLUMN     "proof_metadata" JSONB;
 
 -- CreateIndex
-CREATE INDEX "donations_competitionId_kind" ON "donations"("competitionId", "kind");
+--
+-- Sem CONCURRENTLY de proposito: o Prisma envelopa migrations em transacao, e
+-- CREATE INDEX CONCURRENTLY nao roda dentro de transacao (Postgres 25001).
+--
+-- Este CREATE INDEX pega lock que bloqueia ESCRITA em "donations" enquanto
+-- constroi. Em producao, aplique o PROD_RUNBOOK.sql deste diretorio ANTES do
+-- `prisma migrate deploy`: ele cria o mesmo indice com CONCURRENTLY, e o
+-- IF NOT EXISTS abaixo torna esta linha no-op depois — a migration e marcada
+-- como aplicada normalmente, sem `migrate resolve` na mao.
+CREATE INDEX IF NOT EXISTS "donations_competitionId_kind" ON "donations"("competitionId", "kind");

--- a/server/db/migrations/20260730154008_add_participation_mode/migration.sql
+++ b/server/db/migrations/20260730154008_add_participation_mode/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "CompetitionMode" AS ENUM ('donation', 'participation');
+
+-- CreateEnum
+CREATE TYPE "RegistrationKind" AS ENUM ('donation', 'participation');
+
+-- AlterEnum
+ALTER TYPE "ProofType" ADD VALUE 'any';
+
+-- AlterTable
+ALTER TABLE "competitions" ADD COLUMN     "mode" "CompetitionMode" NOT NULL DEFAULT 'donation';
+
+-- NOTA: o `prisma migrate dev` tambem gerou aqui um
+-- `ALTER COLUMN "autoApprove" DROP NOT NULL`, que foi REMOVIDO de proposito.
+--
+-- Aquilo e drift pre-existente, nao parte desta feature: a migration
+-- 20250319190955 criou a coluna como `BOOLEAN NOT NULL DEFAULT true`, enquanto o
+-- schema.prisma declara `Boolean?`. Mudar a nulidade de uma coluna de producao
+-- que nao tem relacao com esta mudanca nao cabe neste PR — o drift precisa ser
+-- resolvido deliberadamente, em mudanca propria.
+
+-- AlterTable
+ALTER TABLE "donations" ADD COLUMN     "kind" "RegistrationKind" NOT NULL DEFAULT 'donation',
+ADD COLUMN     "proof_metadata" JSONB;
+
+-- CreateIndex
+CREATE INDEX "donations_competitionId_kind" ON "donations"("competitionId", "kind");

--- a/server/db/migrations/20260730154008_add_participation_mode/migration.sql
+++ b/server/db/migrations/20260730154008_add_participation_mode/migration.sql
@@ -1,14 +1,36 @@
--- CreateEnum
-CREATE TYPE "CompetitionMode" AS ENUM ('donation', 'participation');
+-- Migration IDEMPOTENTE de ponta a ponta, de proposito.
+--
+-- Em producao o PROD_RUNBOOK.sql deste diretorio deve ser aplicado ANTES do
+-- `prisma migrate deploy`: ele cria os mesmos objetos na ordem certa, com
+-- CREATE INDEX CONCURRENTLY, que nao bloqueia escrita em "donations". Como todo
+-- statement aqui e idempotente, depois do runbook esta migration vira no-op
+-- inteira e o Prisma a marca como aplicada sem `migrate resolve` na mao.
+--
+-- Em dev e CI, onde a tabela e pequena, rodar so esta migration basta.
 
 -- CreateEnum
-CREATE TYPE "RegistrationKind" AS ENUM ('donation', 'participation');
+-- CREATE TYPE nao aceita IF NOT EXISTS, daí o DO block.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'CompetitionMode') THEN
+    CREATE TYPE "CompetitionMode" AS ENUM ('donation', 'participation');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'RegistrationKind') THEN
+    CREATE TYPE "RegistrationKind" AS ENUM ('donation', 'participation');
+  END IF;
+END
+$$;
 
 -- AlterEnum
-ALTER TYPE "ProofType" ADD VALUE 'any';
+-- Apenas ADICIONA o valor. Usar valor novo de enum na mesma transacao em que ele
+-- foi criado e proibido pelo Postgres, entao nada aqui pode referenciar 'any'.
+ALTER TYPE "ProofType" ADD VALUE IF NOT EXISTS 'any';
 
 -- AlterTable
-ALTER TABLE "competitions" ADD COLUMN     "mode" "CompetitionMode" NOT NULL DEFAULT 'donation';
+-- ADD COLUMN com DEFAULT e metadata-only a partir do PG 11: nao reescreve a
+-- tabela, entao o lock e curto.
+ALTER TABLE "competitions"
+  ADD COLUMN IF NOT EXISTS "mode" "CompetitionMode" NOT NULL DEFAULT 'donation';
 
 -- NOTA: o `prisma migrate dev` tambem gerou aqui um
 -- `ALTER COLUMN "autoApprove" DROP NOT NULL`, que foi REMOVIDO de proposito.
@@ -20,17 +42,15 @@ ALTER TABLE "competitions" ADD COLUMN     "mode" "CompetitionMode" NOT NULL DEFA
 -- resolvido deliberadamente, em mudanca propria.
 
 -- AlterTable
-ALTER TABLE "donations" ADD COLUMN     "kind" "RegistrationKind" NOT NULL DEFAULT 'donation',
-ADD COLUMN     "proof_metadata" JSONB;
+ALTER TABLE "donations"
+  ADD COLUMN IF NOT EXISTS "kind" "RegistrationKind" NOT NULL DEFAULT 'donation';
+
+ALTER TABLE "donations"
+  ADD COLUMN IF NOT EXISTS "proof_metadata" JSONB;
 
 -- CreateIndex
---
--- Sem CONCURRENTLY de proposito: o Prisma envelopa migrations em transacao, e
--- CREATE INDEX CONCURRENTLY nao roda dentro de transacao (Postgres 25001).
---
--- Este CREATE INDEX pega lock que bloqueia ESCRITA em "donations" enquanto
--- constroi. Em producao, aplique o PROD_RUNBOOK.sql deste diretorio ANTES do
--- `prisma migrate deploy`: ele cria o mesmo indice com CONCURRENTLY, e o
--- IF NOT EXISTS abaixo torna esta linha no-op depois — a migration e marcada
--- como aplicada normalmente, sem `migrate resolve` na mao.
-CREATE INDEX IF NOT EXISTS "donations_competitionId_kind" ON "donations"("competitionId", "kind");
+-- Sem CONCURRENTLY porque o Prisma envelopa migrations em transacao e o Postgres
+-- recusa CREATE INDEX CONCURRENTLY dentro de transacao (25001). Em producao,
+-- prefira o PROD_RUNBOOK.sql — ver comentario no topo.
+CREATE INDEX IF NOT EXISTS "donations_competitionId_kind"
+  ON "donations" ("competitionId", "kind");

--- a/server/db/schema.prisma
+++ b/server/db/schema.prisma
@@ -48,6 +48,9 @@ model competitions {
   has_likes               Boolean?   @default(false)
   autoApprove             Boolean?   @default(true)
   webhook_configs         Json?
+  // Copa de participacao conta gente que entrou na campanha, nao bolsas de
+  // sangue. Default donation preserva o comportamento de todas as copas atuais.
+  mode                    CompetitionMode @default(donation)
 
   competitionTeams competitionTeams[]
   donations        donations[]
@@ -84,6 +87,11 @@ model donations {
   influenceId       Int?
   extraFields       Json?
   proof             String?               @db.VarChar(255)
+  // O que esta linha E. Decide se o registro alimenta o historico de doacoes
+  // do hemocione-id: participacao nao e bolsa de sangue.
+  kind              RegistrationKind      @default(donation)
+  // Geolocalizacao best-effort da participacao. Ver utils/geo.ts.
+  proof_metadata    Json?
   createdAt         DateTime              @default(now())
   donationDate      DateTime?             @default(now())
   updatedAt         DateTime              @updatedAt
@@ -93,6 +101,7 @@ model donations {
   status            ProofValidationStatus @default(approved)
 
   @@unique([user_email, competitionId])
+  @@index([competitionId, kind], map: "donations_competitionId_kind") // relatorio por tipo de registro sem varrer a competicao inteira
   @@index([competitionId, hemocioneID], map: "donations_competitionId_hemocioneID") // HemocioneID is the unique identifier for the user in the competition. will be unique in the future, since there are donations with only emails in the database
   @@index([hemocioneID, user_email], map: "donations_hemocioneID") // find donations by hemocioneID
 }
@@ -124,4 +133,18 @@ model influence {
 enum ProofType {
   selfie
   document
+  // Prova permissiva: aceita qualquer registro da ida ao banco de sangue.
+  // Necessario porque quem foi reprovado na pre-triagem nao tem foto de doacao
+  // para enviar — o comprovante da pre-triagem serve.
+  any
+}
+
+enum CompetitionMode {
+  donation
+  participation
+}
+
+enum RegistrationKind {
+  donation
+  participation
 }

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -1,6 +1,7 @@
 import { dbClient } from "../db";
 import { runAsync } from "~/utils/runAsync";
 import { buildAndSendDonationToHemocioneIdQueue } from "./hemocioneId";
+import type { ProofMetadata } from "~/utils/geo";
 
 export const registerDonation = async (
   competitionId: number,
@@ -13,9 +14,12 @@ export const registerDonation = async (
     proof?: string;
     influenceId?: number;
     status: "pending" | "approved" | "rejected";
+    kind?: "donation" | "participation";
+    proof_metadata?: ProofMetadata;
   }
 ) => {
   const { user_name, user_email, extraFields, hemocioneID, proof } = payload;
+  const kind = payload.kind ?? "donation";
   const donation = await dbClient.$transaction(async (db) => {
     const createdDonation = await db.donations.create({
       data: {
@@ -25,12 +29,18 @@ export const registerDonation = async (
         competitionTeamId: competitionTeamId,
         competitionId: competitionId,
         influenceId: payload.influenceId,
+        kind,
         ...(extraFields ? { extraFields } : {}),
         ...(proof ? { proof } : {}),
+        ...(payload.proof_metadata
+          ? { proof_metadata: payload.proof_metadata as object }
+          : {}),
         status: payload.status,
       },
     });
 
+    // O contador soma os dois tipos de proposito: numa copa participativa o
+    // ranking E de participacao. Assim getCompetitionRanking nao muda.
     await db.competitionTeams.update({
       where: {
         id: competitionTeamId,
@@ -56,7 +66,13 @@ export const registerDonation = async (
     }
     return createdDonation;
   });
-  runAsync(buildAndSendDonationToHemocioneIdQueue(donation, competitionId));
+
+  // GATE: participacao NAO e bolsa de sangue. Sem isso, quem registrasse
+  // participacao teria uma doacao aparecendo no historico do hemocione-id.
+  if (kind === "donation") {
+    runAsync(buildAndSendDonationToHemocioneIdQueue(donation, competitionId));
+  }
+
   return donation;
 };
 
@@ -93,6 +109,8 @@ export const getCompetitionUserDonations = async (data: {
       },
     },
     where: {
+      // Participacao nao entra no historico de doacoes do usuario.
+      kind: "donation",
       OR: [
         {
           hemocioneID: hemocioneId,

--- a/server/services/ondedoar.ts
+++ b/server/services/ondedoar.ts
@@ -1,4 +1,8 @@
-const NEAREST_TIMEOUT_MS = 4000;
+// Este lookup acontece no caminho do request de registro, entao o timeout e o
+// teto de latencia que ele adiciona. 1.5s e suficiente para uma consulta com
+// indice 2dsphere e mantem o custo aceitavel — e, como a geo e best-effort,
+// estourar o prazo apenas resulta em geoValidated=false.
+const NEAREST_TIMEOUT_MS = 1500;
 
 /**
  * Consulta o ondedoar pelo banco de sangue mais proximo.

--- a/server/services/ondedoar.ts
+++ b/server/services/ondedoar.ts
@@ -1,0 +1,37 @@
+const NEAREST_TIMEOUT_MS = 4000;
+
+/**
+ * Consulta o ondedoar pelo banco de sangue mais proximo.
+ *
+ * Devolve null em QUALQUER falha — rede, timeout, formato inesperado. A
+ * geolocalizacao e best-effort e nao pode derrubar um registro de participacao.
+ */
+export async function findNearestBloodBank(
+  lat: number,
+  lng: number,
+  maxDistanceMeters: number,
+): Promise<{ pointId: string; distanceMeters: number } | null> {
+  const config = useRuntimeConfig();
+  const base = config.ondeDoarApiUrl as string;
+  if (!base) return null;
+
+  try {
+    const url = new URL("/api/v1/points/nearest", base);
+    url.searchParams.set("lat", String(lat));
+    url.searchParams.set("lng", String(lng));
+    url.searchParams.set("maxDistance", String(maxDistanceMeters));
+
+    const result = await $fetch<{
+      point?: { _id?: string };
+      distanceMeters?: number;
+    } | null>(url.toString(), { timeout: NEAREST_TIMEOUT_MS });
+
+    const pointId = result?.point?._id;
+    if (!pointId || typeof result?.distanceMeters !== "number") return null;
+
+    return { pointId: String(pointId), distanceMeters: result.distanceMeters };
+  } catch (error) {
+    console.warn("[ondedoar] nearest lookup failed, continuing without geo", error);
+    return null;
+  }
+}

--- a/store/user.ts
+++ b/store/user.ts
@@ -28,23 +28,42 @@ export const getUserInfluence = async (
   );
 };
 
+export type RegisterDonationPayload = {
+  proof: string;
+  extraFields: ExtraFieldsResponse;
+  competitionTeamId: number;
+  influenceId?: number;
+  competitionName?: string;
+  /** URL do comprovante de pre-triagem, quando a pessoa vem daquele fluxo. */
+  proofUrl?: string;
+  /** Autodeclaracao: decide se o registro alimenta o historico do hemocione-id. */
+  kind?: "donation" | "participation";
+  /** Geolocalizacao best-effort, ou o motivo de nao ter vindo. */
+  geo?: { lat: number; lng: number; accuracy?: number } | { reason: string };
+};
+
 export const registerDonation = async (
   competitionSlug: string,
   token: string,
-  payload: {
-    proof: string;
-    extraFields: ExtraFieldsResponse;
-    competitionTeamId: number;
-    influenceId?: number;
-    competitionName?: string;
-  }
+  payload: RegisterDonationPayload
 ) => {
-  const { proof, extraFields, competitionTeamId, influenceId } = payload;
+  const {
+    proof,
+    proofUrl,
+    kind,
+    geo,
+    extraFields,
+    competitionTeamId,
+    influenceId,
+  } = payload;
   return await $fetch(`/api/v1/competitions/${competitionSlug}/donations`, {
     method: "POST",
     body: {
       competitionTeamId,
       proof,
+      proofUrl,
+      kind,
+      geo,
       extraFields,
       influenceId,
     },
@@ -157,13 +176,7 @@ export const useUserStore = defineStore("user", {
     },
     async registerDonation(
       competitionSlug: string,
-      payload: {
-        proof: string;
-        extraFields: ExtraFieldsResponse;
-        competitionTeamId: number;
-        influenceId?: number;
-        competitionName?: string;
-      }
+      payload: RegisterDonationPayload
     ) {
       if (!this.token) return;
 
@@ -173,7 +186,12 @@ export const useUserStore = defineStore("user", {
         payload
       );
 
-      if (this.iframed && payload.competitionName) {
+      // Mesmo gate do servidor, aplicado aqui tambem: este caminho registra
+      // doacao virtual no app via SDK e passaria por fora do gate da fila do
+      // hemocione-id. Participacao nao e bolsa de sangue.
+      const isDonation = (payload.kind ?? "donation") === "donation";
+
+      if (isDonation && this.iframed && payload.competitionName) {
         const sdk = useHemocioneSdk();
         if (sdk) {
           sdk

--- a/utils/geo.test.ts
+++ b/utils/geo.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { resolveGeoValidation } from "./geo";
+
+const capturedAt = new Date("2026-07-30T13:00:00.000Z");
+const coords = { lat: -23.55, lng: -46.63, accuracy: 20 };
+
+describe("resolveGeoValidation", () => {
+  it("valida quando o ponto esta dentro do raio", () => {
+    expect(
+      resolveGeoValidation({
+        coords,
+        capturedAt,
+        nearest: { pointId: "665f", distanceMeters: 137 },
+        maxDistanceMeters: 500,
+      }),
+    ).toEqual({
+      lat: -23.55,
+      lng: -46.63,
+      accuracy: 20,
+      capturedAt,
+      geoValidated: true,
+      bloodBankPointId: "665f",
+      distanceMeters: 137,
+    });
+  });
+
+  it("valida no limite exato do raio", () => {
+    const result = resolveGeoValidation({
+      coords,
+      capturedAt,
+      nearest: { pointId: "665f", distanceMeters: 500 },
+      maxDistanceMeters: 500,
+    });
+    expect(result.geoValidated).toBe(true);
+  });
+
+  it("nao valida fora do raio, mas guarda as coordenadas", () => {
+    const result = resolveGeoValidation({
+      coords,
+      capturedAt,
+      nearest: { pointId: "665f", distanceMeters: 900 },
+      maxDistanceMeters: 500,
+    });
+    expect(result.geoValidated).toBe(false);
+    expect(result.lat).toBe(-23.55);
+    expect(result.bloodBankPointId).toBeUndefined();
+    expect(result.distanceMeters).toBe(900);
+    expect(result.reason).toBe("no-point-nearby");
+  });
+
+  it("nao valida quando nenhum ponto foi encontrado", () => {
+    const result = resolveGeoValidation({
+      coords,
+      capturedAt,
+      nearest: null,
+      maxDistanceMeters: 500,
+    });
+    expect(result.geoValidated).toBe(false);
+    expect(result.lat).toBe(-23.55);
+    expect(result.reason).toBe("no-point-nearby");
+  });
+
+  it("registra o motivo quando a geo nao foi obtida", () => {
+    expect(resolveGeoValidation({ coords: null, reason: "denied" })).toEqual({
+      geoValidated: false,
+      reason: "denied",
+    });
+    expect(resolveGeoValidation({ coords: null, reason: "timeout" })).toEqual({
+      geoValidated: false,
+      reason: "timeout",
+    });
+  });
+
+  it("usa 'unavailable' como motivo padrao", () => {
+    expect(resolveGeoValidation({ coords: null })).toEqual({
+      geoValidated: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("usa 500m como raio padrao", () => {
+    expect(
+      resolveGeoValidation({
+        coords,
+        nearest: { pointId: "a", distanceMeters: 499 },
+      }).geoValidated,
+    ).toBe(true);
+    expect(
+      resolveGeoValidation({
+        coords,
+        nearest: { pointId: "a", distanceMeters: 501 },
+      }).geoValidated,
+    ).toBe(false);
+  });
+});

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -1,0 +1,71 @@
+export type GeoFailureReason =
+  | "denied"
+  | "timeout"
+  | "unavailable"
+  | "no-point-nearby";
+
+export type ProofMetadata = {
+  lat?: number;
+  lng?: number;
+  accuracy?: number;
+  capturedAt?: Date;
+  geoValidated: boolean;
+  bloodBankPointId?: string;
+  distanceMeters?: number;
+  reason?: GeoFailureReason;
+};
+
+type Input = {
+  coords: { lat: number; lng: number; accuracy?: number } | null;
+  capturedAt?: Date;
+  nearest?: { pointId: string; distanceMeters: number } | null;
+  maxDistanceMeters?: number;
+  reason?: GeoFailureReason;
+};
+
+/**
+ * Monta o proof_metadata de um registro de participacao.
+ *
+ * NUNCA lanca: geolocalizacao e enriquecimento de prova, nao gate. Nada aqui
+ * pode impedir alguem de registrar participacao — nem permissao negada, nem
+ * app antigo sem allow="geolocation", nem ondedoar fora do ar.
+ *
+ * As coordenadas sao guardadas mesmo quando nenhum banco de sangue esta dentro
+ * do raio, para dar visibilidade sem bloquear registro.
+ */
+export function resolveGeoValidation(input: Input): ProofMetadata {
+  const {
+    coords,
+    capturedAt,
+    nearest,
+    maxDistanceMeters = 500,
+    reason,
+  } = input;
+
+  if (!coords) {
+    return { geoValidated: false, reason: reason ?? "unavailable" };
+  }
+
+  const base: ProofMetadata = {
+    lat: coords.lat,
+    lng: coords.lng,
+    accuracy: coords.accuracy,
+    capturedAt,
+    geoValidated: false,
+  };
+
+  if (!nearest) {
+    return { ...base, reason: "no-point-nearby" };
+  }
+
+  const withinRadius = nearest.distanceMeters <= maxDistanceMeters;
+
+  return {
+    ...base,
+    geoValidated: withinRadius,
+    distanceMeters: nearest.distanceMeters,
+    ...(withinRadius
+      ? { bloodBankPointId: nearest.pointId }
+      : { reason: "no-point-nearby" as const }),
+  };
+}

--- a/utils/proofUrl.test.ts
+++ b/utils/proofUrl.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedProofUrl } from "./proofUrl";
+
+const allowed = [
+  "possodoar.hemocione.com.br",
+  "possodoar.d.hemocione.com.br",
+  "cdn.hemocione.com.br",
+];
+
+describe("isAllowedProofUrl", () => {
+  it("aceita host allowlistado em https", () => {
+    expect(
+      isAllowedProofUrl(
+        "https://possodoar.hemocione.com.br/comprovante/abc",
+        allowed,
+      ),
+    ).toBe(true);
+    expect(isAllowedProofUrl("https://cdn.hemocione.com.br/x.jpg", allowed)).toBe(
+      true,
+    );
+  });
+
+  it("recusa host fora da allowlist", () => {
+    expect(isAllowedProofUrl("https://evil.com/x.jpg", allowed)).toBe(false);
+  });
+
+  it("recusa subdominio que apenas termina com host permitido", () => {
+    expect(
+      isAllowedProofUrl("https://cdn.hemocione.com.br.evil.com/x", allowed),
+    ).toBe(false);
+  });
+
+  it("recusa host permitido usado como userinfo", () => {
+    expect(
+      isAllowedProofUrl("https://cdn.hemocione.com.br@evil.com/x", allowed),
+    ).toBe(false);
+  });
+
+  it("recusa http — o comprovante e servido por https", () => {
+    expect(isAllowedProofUrl("http://cdn.hemocione.com.br/x.jpg", allowed)).toBe(
+      false,
+    );
+  });
+
+  it("recusa esquemas nao-http", () => {
+    expect(isAllowedProofUrl("javascript:alert(1)", allowed)).toBe(false);
+    expect(isAllowedProofUrl("data:text/html,x", allowed)).toBe(false);
+  });
+
+  it("recusa vazio, ausente e lixo", () => {
+    expect(isAllowedProofUrl(undefined, allowed)).toBe(false);
+    expect(isAllowedProofUrl(null, allowed)).toBe(false);
+    expect(isAllowedProofUrl("", allowed)).toBe(false);
+    expect(isAllowedProofUrl("not a url", allowed)).toBe(false);
+  });
+
+  it("recusa tudo quando a allowlist esta vazia", () => {
+    expect(isAllowedProofUrl("https://cdn.hemocione.com.br/x.jpg", [])).toBe(
+      false,
+    );
+  });
+});

--- a/utils/proofUrl.ts
+++ b/utils/proofUrl.ts
@@ -1,0 +1,28 @@
+/**
+ * O proofUrl pode chegar por query string: o can-donate manda a URL do
+ * comprovante de pre-triagem para quem foi reprovado e vai registrar
+ * participacao. Sem allowlist, o campo proof da copa viraria armazem de link
+ * arbitrario.
+ *
+ * Compara host EXATO de proposito. endsWith deixaria passar
+ * "cdn.hemocione.com.br.evil.com", e userinfo
+ * ("https://cdn.hemocione.com.br@evil.com") engana leitura humana.
+ */
+export function isAllowedProofUrl(
+  url: string | undefined | null,
+  allowedHosts: string[],
+): boolean {
+  if (!url || !allowedHosts.length) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.username || parsed.password) return false;
+
+  return allowedHosts.includes(parsed.hostname);
+}

--- a/utils/validateExtraFields.test.ts
+++ b/utils/validateExtraFields.test.ts
@@ -60,6 +60,13 @@ describe("isValidExtraFieldsResponse", () => {
     ).toBe(false);
   });
 
+  it("recusa entrada malformada sem estourar ao ler slug", () => {
+    expect(isValidExtraFieldsResponse(fields, [null as never])).toBe(false);
+    expect(isValidExtraFieldsResponse(fields, ["matricula" as never])).toBe(false);
+    expect(isValidExtraFieldsResponse(fields, [123 as never])).toBe(false);
+    expect(isValidExtraFieldsResponse(fields, [{} as never])).toBe(false);
+  });
+
   it("recusa valor que nao e string", () => {
     expect(
       isValidExtraFieldsResponse(fields, [

--- a/utils/validateExtraFields.test.ts
+++ b/utils/validateExtraFields.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidExtraFieldsResponse,
+  type ExtraFields,
+} from "./validateExtraFields";
+
+const fields: ExtraFields = [
+  { slug: "matricula", label: "Matrícula", required: true, type: "text" },
+  { slug: "curso", label: "Curso", required: false, type: "text" },
+];
+
+describe("isValidExtraFieldsResponse", () => {
+  it("aceita quando o obrigatorio esta preenchido", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [
+        { slug: "matricula", value: "20261234" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("aceita opcional preenchido junto", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [
+        { slug: "matricula", value: "20261234" },
+        { slug: "curso", value: "Medicina" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("recusa quando o obrigatorio esta ausente", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [{ slug: "curso", value: "Medicina" }]),
+    ).toBe(false);
+  });
+
+  it("recusa obrigatorio vazio ou so espacos", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [{ slug: "matricula", value: "" }]),
+    ).toBe(false);
+    expect(
+      isValidExtraFieldsResponse(fields, [{ slug: "matricula", value: "   " }]),
+    ).toBe(false);
+  });
+
+  it("aceita opcional ausente", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [
+        { slug: "matricula", value: "20261234" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("aceita qualquer resposta quando nao ha campo configurado", () => {
+    expect(isValidExtraFieldsResponse([], [])).toBe(true);
+  });
+
+  it("recusa resposta que nao e array", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, undefined as never),
+    ).toBe(false);
+  });
+
+  it("recusa valor que nao e string", () => {
+    expect(
+      isValidExtraFieldsResponse(fields, [
+        { slug: "matricula", value: 123 as never },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/utils/validateExtraFields.ts
+++ b/utils/validateExtraFields.ts
@@ -20,16 +20,31 @@ export type ExtraFieldsResponse = ExtraFieldResponse[];
 
 // extra fields are configured in the competition
 // extra fields response are the user input in the donation for each extra field
-export const isValidExtraFieldsResponse = (extraFields: ExtraFields, extraFieldsResponse: ExtraFieldsResponse) => {
+//
+// A checagem de tipo que existia aqui comparava `response.type`, campo que nao
+// existe em ExtraFieldResponse — o resultado era `undefined !== 'text'`, sempre
+// verdadeiro, o que reprovaria qualquer campo preenchido. O bug nunca apareceu
+// porque a funcao nunca era chamada; ela virou TODO no handler de registro.
+// Agora que a matricula do aluno depende dela, valida o que importa de fato:
+// campo obrigatorio presente e nao vazio.
+export const isValidExtraFieldsResponse = (
+  extraFields: ExtraFields,
+  extraFieldsResponse: ExtraFieldsResponse,
+) => {
+  if (!Array.isArray(extraFieldsResponse)) return false;
+
   for (const extraField of extraFields) {
     const response = extraFieldsResponse.find((e) => e.slug === extraField.slug);
-    if (!response && extraField.required) {
-      return false
+
+    if (extraField.required) {
+      if (!response) return false;
+      if (typeof response.value !== "string" || !response.value.trim()) {
+        return false;
+      }
     }
 
-    if (response && response.type !== extraField.type) {
-      return false
-    }
+    if (response && typeof response.value !== "string") return false;
   }
-  return true
-}
+
+  return true;
+};

--- a/utils/validateExtraFields.ts
+++ b/utils/validateExtraFields.ts
@@ -36,7 +36,10 @@ export const isValidExtraFieldsResponse = (
   // A resposta vem do corpo do request: uma entrada null, string ou numero faria
   // o acesso a `.slug` estourar dentro do handler de registro.
   const isEntry = (e: unknown): e is ExtraFieldResponse =>
-    typeof e === "object" && e !== null && "slug" in e;
+    typeof e === "object" &&
+    e !== null &&
+    !Array.isArray(e) &&
+    typeof (e as { slug?: unknown }).slug === "string";
 
   if (!extraFieldsResponse.every(isEntry)) return false;
 

--- a/utils/validateExtraFields.ts
+++ b/utils/validateExtraFields.ts
@@ -33,6 +33,13 @@ export const isValidExtraFieldsResponse = (
 ) => {
   if (!Array.isArray(extraFieldsResponse)) return false;
 
+  // A resposta vem do corpo do request: uma entrada null, string ou numero faria
+  // o acesso a `.slug` estourar dentro do handler de registro.
+  const isEntry = (e: unknown): e is ExtraFieldResponse =>
+    typeof e === "object" && e !== null && "slug" in e;
+
+  if (!extraFieldsResponse.every(isEntry)) return false;
+
   for (const extraField of extraFields) {
     const response = extraFieldsResponse.find((e) => e.slug === extraField.slug);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,32 @@
     magic-string "^0.27.0"
     unplugin "^1.0.1"
 
+"@emnapi/core@2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-2.0.0-alpha.3.tgz#049ace671f30274d6a4d161d3b771138b862f704"
+  integrity sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==
+  dependencies:
+    "@emnapi/wasi-threads" "2.0.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz#aef04c35c9a83c23ab0f251f03095440edd7ad5f"
+  integrity sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emnapi/runtime@^0.45.0":
   version "0.45.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-0.45.0.tgz#e754de04c683263f34fd0c7f32adfe718bbe4ddd"
   integrity sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz#1c92919328be1f6ab79fb60a67ccf3d2e62cd48b"
+  integrity sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==
   dependencies:
     tslib "^2.4.0"
 
@@ -1266,10 +1288,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@hemocione/sdk@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@hemocione/sdk/-/sdk-0.0.3.tgz#3253371eaac644db78520404b100442d21071eb7"
-  integrity sha512-aBMJOCc2QVnVuFocVFz12/4WpZrObwWTerlqNclM0d5nOMxrbeqTtJJTdV0cMWClmT4vFdNXwSnB9ssjO5LnBw==
+"@hemocione/sdk@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@hemocione/sdk/-/sdk-0.0.5.tgz#9c4e24c171007eebb857ee4578b2ecaebf9a3cb4"
+  integrity sha512-v51LxroRiNOs6M+/7nlMOR4XlMk3dXQz5RNdHbdaNddru1D+dZ6v3JaJwwzyz+TCEmoOz8v5EixPXIDFxQZuqQ==
 
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.14"
@@ -1457,6 +1479,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz#72e45707cf240fa6b081d0366f8265b0cd10197f"
@@ -1491,6 +1518,13 @@
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
+
+"@napi-rs/wasm-runtime@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz#9657eaa103c1cedd9411012595faf8f476608f15"
+  integrity sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
 
 "@netlify/functions@^2.4.0":
   version "2.4.0"
@@ -1972,6 +2006,11 @@
     google-fonts-helper "^3.4.0"
     pathe "^1.1.1"
 
+"@oxc-project/types@=0.142.0":
+  version "0.142.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.142.0.tgz#0b4bd7841ef3dd267a69184b97452cc0b313fb52"
+  integrity sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==
+
 "@parcel/watcher-android-arm64@2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.3.0.tgz#d82e74bb564ebd4d8a88791d273a3d2bd61e27ab"
@@ -2219,6 +2258,90 @@
   integrity sha512-6OQsNxTyhvG+T2Ksr8FPFpuPeL4r9u0JF0OZHUBI/Uy9SS43sPyAIutt4ZEAyqWQt104ERh70EZedkHZKsnNbg==
   dependencies:
     "@prisma/debug" "5.9.1"
+
+"@rolldown/binding-android-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz#dbc5a2453c063aa9b2974410d19b4be2e730856f"
+  integrity sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==
+
+"@rolldown/binding-darwin-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz#dd43dc12d5acd6a34edbd48cdf3008f5d4c52e2a"
+  integrity sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==
+
+"@rolldown/binding-darwin-x64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz#00b32d5e0adba8aab6925633280ed1bf6d90c1d2"
+  integrity sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==
+
+"@rolldown/binding-freebsd-x64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz#0884face257d2763024754abae947e1c0b7b6c24"
+  integrity sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz#a82580ac5cf3030c65ccf6181326d64f91889524"
+  integrity sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz#5221b6c7eab55f82d776e65f9146d387cec3791e"
+  integrity sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==
+
+"@rolldown/binding-linux-arm64-musl@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz#3552c35275daad1f1553f1f29452aa62bffbd120"
+  integrity sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz#6b4972d32614b70885c5bf580695fb1e365b5313"
+  integrity sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz#42ebada72e617003e30b67ac9b4afff66a75b15a"
+  integrity sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==
+
+"@rolldown/binding-linux-x64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz#37734bbf4b90cf39da5301f18b6f089b65a745d9"
+  integrity sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==
+
+"@rolldown/binding-linux-x64-musl@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz#95170913f28700fbd56c8d85649e3960abe5632f"
+  integrity sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==
+
+"@rolldown/binding-openharmony-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz#d163a5fe25d3542b7b325c05e0211825f42d2b5c"
+  integrity sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==
+
+"@rolldown/binding-wasm32-wasi@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz#8333205b61997d298fb433214a99b01874459342"
+  integrity sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==
+  dependencies:
+    "@emnapi/core" "2.0.0-alpha.3"
+    "@emnapi/runtime" "2.0.0-alpha.3"
+    "@napi-rs/wasm-runtime" "^1.2.0"
+
+"@rolldown/binding-win32-arm64-msvc@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz#c730559e7d74fa9ba24106d9104e7c8dc25f2236"
+  integrity sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz#ea040d8719fe26c8b0d781081329b20a1606a006"
+  integrity sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
 "@rollup/plugin-alias@^5.0.1":
   version "5.1.0"
@@ -2815,6 +2938,11 @@
     "@smithy/util-buffer-from" "^3.0.0"
     tslib "^2.6.2"
 
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -2832,6 +2960,26 @@
   dependencies:
     "@tufjs/canonical-json" "2.0.0"
     minimatch "^9.0.3"
+
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.5"
@@ -2979,6 +3127,66 @@
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz#b4569fcb1faac054eba4f5efc1aaf4d39f4379e5"
   integrity sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==
+
+"@vitest/expect@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.10.tgz#799c06fc44bb0cf7e2784137b627c5cc173285d4"
+  integrity sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.10.tgz#2413987ab4cd7fa1c2b614b404c407bf6ad1ead1"
+  integrity sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==
+  dependencies:
+    "@vitest/spy" "4.1.10"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.10.tgz#75542e7273a08cc10fd4d8dad4e3eb1f16cd958c"
+  integrity sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.10.tgz#febf0a21a9168421422d1955370e606feab60355"
+  integrity sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==
+  dependencies:
+    "@vitest/utils" "4.1.10"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.10.tgz#7e3e9fec7d4d47232e493cfdcbd2170de4371c04"
+  integrity sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.10.tgz#5c0bfa97b56bba9e37403c976db776ff6ab56f65"
+  integrity sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==
+
+"@vitest/utils@4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.10.tgz#ffc71055f18bfccb1fd0586365ebc2824892e403"
+  integrity sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==
+  dependencies:
+    "@vitest/pretty-format" "4.1.10"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@vue-macros/common@^1.8.0":
   version "1.9.0"
@@ -3331,6 +3539,11 @@ array-back@^4.0.1, array-back@^4.0.2:
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 ast-kit@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/ast-kit/-/ast-kit-0.11.2.tgz#5951329c7fd311304cd30729619639323974893f"
@@ -3673,6 +3886,11 @@ caniuse-lite@^1.0.30001580:
   version "1.0.30001583"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001583.tgz#abb2970cc370801dc7e27bf290509dc132cfa390"
   integrity sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -4215,6 +4433,11 @@ detect-libc@^2.0.0, detect-libc@^2.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
   integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
 
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
 devalue@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/devalue/-/devalue-4.3.2.tgz#cc44e4cf3872ac5a78229fbce3b77e57032727b5"
@@ -4407,6 +4630,11 @@ error-stack-parser@^2.0.2, error-stack-parser@^2.0.3:
   integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
   dependencies:
     stackframe "^1.3.4"
+
+es-module-lexer@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.1.tgz#5bf2df06999dbbe5f006a5f46a11fb9f5b7b391b"
+  integrity sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==
 
 esbuild@^0.18.10:
   version "0.18.20"
@@ -4641,6 +4869,11 @@ execa@^8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
+expect-type@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
+
 exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
@@ -4700,6 +4933,11 @@ fastq@^1.6.0:
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -5679,6 +5917,80 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
+
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
+
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
+
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
+
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
+
 lilconfig@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
@@ -5899,6 +6211,13 @@ magic-string@^0.30.11:
   integrity sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magicast@^0.3.2:
   version "0.3.2"
@@ -6160,6 +6479,11 @@ ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanoid@^3.3.6:
   version "3.3.7"
@@ -6572,6 +6896,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+obug@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
+  integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
+
 ofetch@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.3.3.tgz#588cb806a28e5c66c2c47dd8994f9059a036d8c0"
@@ -6813,6 +7142,11 @@ pathe@^1.1.2:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 perfect-debounce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-1.0.0.tgz#9c2e8bc30b169cc984a58b7d5b28049839591d2a"
@@ -6823,10 +7157,20 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pinia@>=2.1.7:
   version "2.1.7"
@@ -7072,6 +7416,15 @@ postcss@^8.4.27, postcss@^8.4.31:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@^8.5.23:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
+  dependencies:
+    nanoid "^3.3.16"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7313,6 +7666,30 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rolldown@~1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.1.tgz#644204bde3da11e0eaa8d74994be25b90fcf4d44"
+  integrity sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==
+  dependencies:
+    "@oxc-project/types" "=0.142.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.2.1"
+    "@rolldown/binding-darwin-arm64" "1.2.1"
+    "@rolldown/binding-darwin-x64" "1.2.1"
+    "@rolldown/binding-freebsd-x64" "1.2.1"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.1"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.1"
+    "@rolldown/binding-linux-arm64-musl" "1.2.1"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.1"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.1"
+    "@rolldown/binding-linux-x64-gnu" "1.2.1"
+    "@rolldown/binding-linux-x64-musl" "1.2.1"
+    "@rolldown/binding-openharmony-arm64" "1.2.1"
+    "@rolldown/binding-wasm32-wasi" "1.2.1"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.1"
+    "@rolldown/binding-win32-x64-msvc" "1.2.1"
+
 rollup-plugin-visualizer@^5.9.2:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.3.tgz#167c55f44c3026607951e62d4231847acb5f00c1"
@@ -7526,6 +7903,11 @@ shell-quote@^1.8.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -7623,6 +8005,11 @@ source-map-js@^1.0.1, source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -7681,6 +8068,11 @@ stack-generator@^2.0.3:
   dependencies:
     stackframe "^1.3.4"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
@@ -7705,6 +8097,11 @@ std-env@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
+
+std-env@^4.0.0-rc.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.2.0.tgz#8ebe0ec60485668ab47227b312f4254cdf80c9d3"
+  integrity sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==
 
 streamx@^2.15.0:
   version "2.15.5"
@@ -7933,6 +8330,29 @@ tiny-invariant@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.1.tgz#c0168387d3d8d70b6b3c2c0936de5fee738cea20"
+  integrity sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==
 
 titleize@^3.0.0:
   version "3.0.0"
@@ -8430,6 +8850,45 @@ vite-plugin-vue-inspector@^4.0.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.0.tgz#902fcd3dc0312f553c85b6cbc4625dcaca2d8df8"
+  integrity sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.23"
+    rolldown "~1.2.0"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.10:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.10.tgz#7e9285efe264b1167050b7a3a7ff34788e1b7afc"
+  integrity sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==
+  dependencies:
+    "@vitest/expect" "4.1.10"
+    "@vitest/mocker" "4.1.10"
+    "@vitest/pretty-format" "4.1.10"
+    "@vitest/runner" "4.1.10"
+    "@vitest/snapshot" "4.1.10"
+    "@vitest/spy" "4.1.10"
+    "@vitest/utils" "4.1.10"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 vscode-jsonrpc@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
@@ -8567,6 +9026,14 @@ which@^4.0.0:
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wide-align@^1.1.2:
   version "1.1.5"


### PR DESCRIPTION
## O que

A copa ganha um modo **participativa**: conta gente que participou da campanha, não só bolsas de sangue.

- `competitions.mode` e `donations.kind` (`donation` | `participation`)
- `ProofType.any` — prova permissiva, para quem não tem foto de doação
- `donations.proof_metadata` — geolocalização best-effort
- Formulário pergunta **"Você conseguiu doar?"**; a resposta decide se o registro vai para a fila do hemocione-id
- Copy de participação em `register.vue` e `success.vue`

## Por que

Na campanha YDUQS 2026/2, quem é reprovado na pré-triagem também conta para a unidade e pode receber as 20h complementares. Mas participação **não é bolsa de sangue** — não pode virar doação no histórico do doador.

## Decisões que valem review

- **O gate é o ponto crítico deste PR, e são DOIS caminhos.** `registerDonation` só chama `buildAndSendDonationToHemocioneIdQueue` quando `kind === 'donation'` — mas o store também chamava `sdk.registerVirtualDonation` quando iframado, o que registra doação no app **passando por fora do gate do servidor**. Os dois estão fechados. `getCompetitionUserDonations` filtra `kind='donation'` pelo mesmo motivo.
- **`donation_count` continua somando os dois tipos.** Numa copa participativa o ranking *é* de participação — `getCompetitionRanking` não muda.
- **O store fazia whitelist explícita do body**, então os campos novos precisavam ser adicionados lá também; sem isso seriam descartados em silêncio.
- **Geo nunca bloqueia registro.** Permissão negada, app antigo sem `allow="geolocation"`, ondedoar fora do ar — tudo resulta em `geoValidated: false`, nunca em recusa.
- **`isAllowedProofUrl` compara host exato.** `endsWith` deixaria passar `cdn.hemocione.com.br.evil.com`; userinfo (`https://cdn.hemocione.com.br@evil.com`) engana leitura humana e é recusado. Há teste para os dois.

## Dois achados de bug pré-existente

1. **`isValidExtraFieldsResponse` estava quebrada.** Comparava `response.type`, campo que não existe em `ExtraFieldResponse` — o resultado era `undefined !== 'text'`, sempre verdadeiro, o que reprovaria **qualquer** campo preenchido. Nunca apareceu porque a função nunca era chamada (era o `TODO` do handler). Como a matrícula do aluno depende dela agora, reescrevi para validar o que importa: obrigatório presente e não vazio.
2. **Drift de schema não relacionado.** O `prisma migrate dev` gerou também um `ALTER COLUMN "autoApprove" DROP NOT NULL`, porque a migration `20250319190955` criou a coluna `NOT NULL` enquanto o `schema.prisma` declara `Boolean?`. **Removi essa linha da migration** — mudar nulidade de coluna de produção sem relação com esta feature não cabe aqui. O drift continua e merece mudança própria.

## Não-regressão

Copa com `mode='donation'` (todas as existentes, por causa do `@default`) não mostra o campo novo e mantém a copy atual.

## Verificação feita

- **Migration aplicada do zero em PostgreSQL 14 local** (`migrate reset`), confirmando no banco: `ProofType` com `any`, `donations.kind`, `donations.proof_metadata`, índice `donations_competitionId_kind`. Isso também prova que o `ALTER TYPE ADD VALUE` passa dentro da transação que o Prisma envelopa nesta versão.
- **`yarn test` — 23 testes verdes** (allowlist de proofUrl, validação de raio, extraFields).
- **`yarn build` compila** (9.97 MB de output emitido). O build falha depois, no upload de sourcemap do Bugsnag, por falta de `BUGSNAG_API_KEY` local — não é código.

## O gate NÃO foi verificado em runtime

Não observei mensagem na fila do hemocione-id: exigiria credencial de SQS. **Antes de mergear, vale registrar uma participação e uma doação no preview e confirmar que só a segunda emite mensagem.** Ler o código não prova isso.

## A definir antes do deploy

`mode='participation'` e `has_influence` precisam ser setados na copa que o Lucas cadastrou. O CTA de link de indicação **já existia** no `success.vue` sob `v-if="competition?.has_influence"` — não precisou de código, só da flag.

## Depende de

`ondedoar` — endpoint `/api/v1/points/nearest` (PR à parte). Sem ele `findNearestBloodBank` devolve `null` e a geo fica não-validada; nada quebra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added participation-mode competition registration alongside donations (with mode-specific prompts, proof handling, geolocation, and tailored success messaging).
  * Added proof URL allowlisting via runtime configuration and nearest blood bank geo proof metadata.
  * Extended database/enums to store competition mode and registration kind, plus indexing support.

* **Bug Fixes**
  * Hardened proof URL eligibility/selection and restricted participation submissions to participation-mode competitions.
  * Improved extra-field validation to reject malformed or missing required values.

* **Tests**
  * Added Vitest test coverage for geo validation, proof URL allowlisting, and extra-field validation, plus test scripts.

* **Documentation**
  * Added runbook guidance for creating the new database index concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->