### PR TITLE
feat(competitions): expor mode na API de criacao

### DIFF
--- a/server/api/v1/competitions/index.post.ts
+++ b/server/api/v1/competitions/index.post.ts
@@ -17,13 +17,22 @@ export default defineEventHandler(async (event) => {
     influence_controls_team,
     proof_type,
     webhook_configs,
-    autoApprove
+    autoApprove,
+    mode
   } = body;
   if (!name || !startsAt || !endsAt || _.isBoolean(mandatoryProof) === false) {
     throw createError({
       statusCode: 400,
       statusMessage:
         "Bad Request - name, startsAt, mandatoryProof and endsAt are required",
+    });
+  }
+
+  // Sem isso um valor invalido chega no Prisma e volta 500 em vez de 400.
+  if (mode !== undefined && mode !== "donation" && mode !== "participation") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - mode must be 'donation' or 'participation'",
     });
   }
 
@@ -42,7 +51,8 @@ export default defineEventHandler(async (event) => {
     influence_controls_team,
     proof_type,
     webhook_configs,
-    autoApprove
+    autoApprove,
+    mode
   });
 
   return createdCompetition;

--- a/server/services/competitionService.ts
+++ b/server/services/competitionService.ts
@@ -1,5 +1,6 @@
 import { dbClient } from "../db";
 import slugify from "slugify";
+import type { CompetitionMode } from "@prisma/client";
 
 // status 3 = draft, 2 = ativo, 1 = upcoming, 0 = finalizado
 const statusCaseWhenClause = `
@@ -185,7 +186,9 @@ interface CreateCompetitionPayload {
   webhook_configs?: {
     donation_approved: string
   },
-  autoApprove: boolean
+  autoApprove: boolean,
+  // Copa de participacao conta gente que entrou na campanha, nao bolsas.
+  mode?: CompetitionMode
 }
 
 export const createCompetition = async ({
@@ -200,7 +203,8 @@ export const createCompetition = async ({
   influence_controls_team = false,
   proof_type = "selfie",
   webhook_configs,
-  autoApprove = true
+  autoApprove = true,
+  mode = "donation"
 }: CreateCompetitionPayload) => {
   const slug = slugify(name, {
     lower: true,
@@ -222,7 +226,8 @@ export const createCompetition = async ({
       influence_controls_team: has_influence && influence_controls_team,
       proof_type,
       webhook_configs,
-      autoApprove
+      autoApprove,
+      mode
     },
   });
 };

--- a/server/services/competitionService.ts
+++ b/server/services/competitionService.ts
@@ -55,6 +55,11 @@ const getCompetitionBySlugPromise = (slug: string) => {
       extraFields: true,
       mandatory_proof: true,
       proof_type: true,
+      // OBRIGATORIO: o register.vue liga toda a UI de participacao em
+      // `competition.mode`. Fora deste select o campo chega undefined no
+      // frontend e a copa participativa se comporta como copa de doacao,
+      // silenciosamente.
+      mode: true,
       has_influence: true,
       has_likes: true,
       influence_controls_team: true,


### PR DESCRIPTION
## O que

`POST /api/v1/competitions` passa a aceitar `mode` (`donation` | `participation`), com validação no handler.

## Por que

O campo entrou no schema no PR da copa participativa, mas **não era alcançável por nenhum endpoint** — só daria para setar direto no banco. Ou seja: a copa participativa era impossível de cadastrar pelo backoffice, o que inviabiliza a feature na prática.

Descobri tentando cadastrar a copa de teste no ambiente de dev.

## Notas

- Valida o valor no handler: sem isso um `mode` inválido chega no Prisma e volta 500 em vez de 400.
- Default `donation`, então nada muda para quem já usa a API.
- **O `PUT` ainda não aceita `mode`** — dá para criar uma copa participativa, mas não para converter uma existente. Deixei fora para manter o PR mínimo; se for necessário, é a mesma mudança no `editCompetitionBySlug`.

## Verificação

`yarn build` compila (9.97 MB emitidos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a competition mode: Donation or Participation.
  * Competition mode is now saved when creating a competition.
  * Defaults to Donation when no mode is specified.

* **Bug Fixes**
  * Invalid competition modes are rejected with a clear request error instead of causing a server failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->