### PR TITLE
feat(backoffice): mode no PUT de copa + GET de instituicoes com times

### DIFF
--- a/server/api/v1/competitions/[slug]/index.put.ts
+++ b/server/api/v1/competitions/[slug]/index.put.ts
@@ -18,13 +18,22 @@ export default defineEventHandler(async (event) => {
     influence_controls_team,
     proof_type,
     webhook_configs,
-    autoApprove
+    autoApprove,
+    mode
   } = body;
   if (!name || !startsAt || !endsAt || _.isBoolean(mandatoryProof) === false) {
     throw createError({
       statusCode: 400,
       statusMessage:
         "Bad Request - name, startsAt, mandatoryProof and endsAt are required",
+    });
+  }
+
+  // Sem isso um valor invalido chega no Prisma e volta 500 em vez de 400.
+  if (mode !== undefined && mode !== "donation" && mode !== "participation") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - mode must be 'donation' or 'participation'",
     });
   }
 
@@ -43,7 +52,8 @@ export default defineEventHandler(async (event) => {
     influence_controls_team,
     proof_type,
     webhook_configs,
-    autoApprove
+    autoApprove,
+    mode
   });
 
   return editedCompetition

--- a/server/api/v1/institutions/index.get.ts
+++ b/server/api/v1/institutions/index.get.ts
@@ -1,0 +1,9 @@
+import { assertSecretAuth } from "~/server/services/auth";
+import { listInstitutions } from "~/server/services/institutionService";
+
+export default defineEventHandler(async (event) => {
+  // Protegido pelo mesmo secret dos outros endpoints de backoffice: expoe a
+  // estrutura de instituicoes e times, que nao e dado publico.
+  assertSecretAuth(event);
+  return await listInstitutions();
+});

--- a/server/services/competitionService.ts
+++ b/server/services/competitionService.ts
@@ -253,7 +253,9 @@ export const editCompetitionBySlug = async (
     webhook_configs?: {
       donation_approved: string
     },
-    autoApprove: boolean
+    autoApprove: boolean,
+    // Permite converter uma copa existente entre doacao e participacao.
+    mode?: CompetitionMode
   }
 ) => {
   const {
@@ -268,7 +270,8 @@ export const editCompetitionBySlug = async (
     influence_controls_team,
     proof_type = "selfie",
     webhook_configs,
-    autoApprove
+    autoApprove,
+    mode
   } = payload;
   const updatedCompetition = await dbClient.competitions.update({
     where: { slug },
@@ -284,7 +287,9 @@ export const editCompetitionBySlug = async (
       influence_controls_team: has_influence && influence_controls_team,
       proof_type,
       webhook_configs,
-      autoApprove
+      autoApprove,
+      // undefined nao altera a coluna: quem nao manda mode mantem o valor atual.
+      mode
     },
   });
   return updatedCompetition;

--- a/server/services/institutionService.ts
+++ b/server/services/institutionService.ts
@@ -53,3 +53,26 @@ export const deleteInstitution = async (id: number) => {
 
   return deletedInstitution;
 };
+
+/**
+ * Lista instituicoes com seus times.
+ *
+ * Existe porque a API criava times (`POST .../teams/bulk` devolve so um count)
+ * mas nao tinha como LISTAR os ids — e `POST /competitions/:slug/teams/set`
+ * exige teamIds. Sem isto, cadastrar uma copa pelo backoffice obrigava a
+ * adivinhar ids ou ir direto no banco.
+ */
+export const listInstitutions = async () => {
+  return await dbClient.institutions.findMany({
+    select: {
+      id: true,
+      name: true,
+      logo_url: true,
+      teams: {
+        select: { id: true, name: true, logo_url: true },
+        orderBy: { name: "asc" },
+      },
+    },
+    orderBy: { name: "asc" },
+  });
+};


### PR DESCRIPTION
## O que

Duas lacunas do backoffice que apareceram **cadastrando a copa YDUQS no dev de verdade**:

1. **`PUT /competitions/:slug` passa a aceitar `mode`.** Dava para criar uma copa participativa mas não para converter uma existente — uma copa já cadastrada como `donation` ficava presa. `undefined` não altera a coluna, então quem não manda o campo mantém o valor atual.

2. **`GET /institutions` novo**, devolvendo instituições com seus times (id, nome, logo).

## Por que o GET

`POST /institutions/:id/teams/bulk` devolve apenas `{count: 4}`, e `POST /competitions/:slug/teams/set` exige `teamIds`. Não havia nenhum endpoint que listasse times — então cadastrar uma copa pelo backoffice obrigava a **adivinhar ids**.

Foi literalmente o que tive que fazer: varri as copas publicadas procurando o maior team id visível, assumi que os meus eram os 4 seguintes, e só descobri que acertei porque o GET da copa devolveu os nomes. Funcionou, mas é frágil e ninguém deveria precisar disso.

## Notas de review

- O GET está atrás do mesmo `assertSecretAuth` dos outros endpoints de backoffice: a estrutura de instituições e times não é dado público.
- `mode` é validado no handler do PUT, igual no POST — sem isso um valor inválido chega no Prisma e volta 500 em vez de 400.
- Ordenação por nome nos dois níveis, para a listagem ser estável.

## Verificação

`yarn build` compila (9.97 MB emitidos).

Não exercitei os dois endpoints contra o dev ainda — vou fazer depois do merge, incluindo reconferir que o `mode` da copa `trote-solidario-yduqs-20262` sobrevive a um PUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for retrieving institutions, including their teams sorted by name.
  * Competition updates now support selecting either donation or participation mode.

* **Bug Fixes**
  * Invalid competition modes are rejected with a clear 400 error.
  * Existing competition modes are preserved when no new mode is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->