### PR TITLE
feat(ui): vocabulario de participacao nas telas e rankings da copa

### DIFF
--- a/components/flow/general.vue
+++ b/components/flow/general.vue
@@ -3,7 +3,7 @@
     <TemplateCompetitionContent2 :disablePodium="false">
       <template #podium-content>
         <div class="blood-view">
-          <h4>TOTAL DE DOAÇÕES REALIZADAS</h4>
+          <h4>{{ totalLabel }}</h4>
           <h1 class="blood-amount-donation">
             {{ formattedDonationsAmount }}
           </h1>
@@ -26,7 +26,14 @@
 const props = defineProps<{
   donationsAmount: number;
   mappedRankByCompetition: any;
+  // Rotulo do contador. Vem de useCompetitionWording na pagina, para o
+  // componente nao precisar conhecer o modo da copa.
+  totalLabel?: string;
 }>();
+
+const totalLabel = computed(
+  () => props.totalLabel ?? "TOTAL DE DOAÇÕES REALIZADAS",
+);
 
 const formattedDonationsAmount = computed(() => {
   const amount = props.donationsAmount;

--- a/composables/useCompetitionWording.ts
+++ b/composables/useCompetitionWording.ts
@@ -1,0 +1,38 @@
+import type { CompetitionMode } from "@prisma/client";
+
+/**
+ * Vocabulario da copa por modo.
+ *
+ * Numa copa participativa a unidade contada e a PARTICIPACAO, nao a bolsa de
+ * sangue — quem foi reprovado na pre-triagem tambem conta. Falar "doacao" nas
+ * telas e nos rankings daria a entender que so doacao vale, que e justamente o
+ * contrario da campanha.
+ *
+ * Centralizado aqui para nao espalhar ternario por tela: uma copa nova nao
+ * deveria exigir cacar strings pelo repo.
+ */
+export function useCompetitionWording(
+  mode?: MaybeRefOrGetter<CompetitionMode | string | null | undefined>,
+) {
+  const isParticipation = computed(() => toValue(mode) === "participation");
+
+  return {
+    isParticipation,
+    /** "participação" | "doação" */
+    noun: computed(() => (isParticipation.value ? "participação" : "doação")),
+    /** "Participações" | "Doações" — usado como cabecalho de ranking */
+    nounPluralCapitalized: computed(() =>
+      isParticipation.value ? "Participações" : "Doações",
+    ),
+    /** "Registrar Participação" | "Registrar Doação" */
+    registerCta: computed(() =>
+      isParticipation.value ? "Registrar Participação" : "Registrar Doação",
+    ),
+    /** Titulo do contador geral */
+    totalLabel: computed(() =>
+      isParticipation.value
+        ? "TOTAL DE PARTICIPAÇÕES REGISTRADAS"
+        : "TOTAL DE DOAÇÕES REALIZADAS",
+    ),
+  };
+}

--- a/pages/competition/[slug]/index.vue
+++ b/pages/competition/[slug]/index.vue
@@ -42,6 +42,7 @@
           v-if="isGeneralView"
           :mappedRankByCompetition="mappedRankByCompetition"
           :donationsAmount="donationsAmount"
+          :totalLabel="wording.totalLabel.value"
         />
         <FlowEngagement
           v-else-if="isEngagementView"
@@ -93,7 +94,7 @@
             <el-icon>
               <ElIconCirclePlusFilled />
             </el-icon> </template
-          >Registrar doação</el-button
+          >{{ wording.registerCta.value }}</el-button
         >
       </NuxtLink>
     </common-cool-footer>
@@ -118,6 +119,10 @@ const user = computed(() => userStore.user);
 const slug = route.params.slug;
 
 const { data: competition } = await useFetch(`/api/v1/competitions/${slug}`);
+
+// Vocabulario da copa: participativa conta PARTICIPACAO, nao bolsa de sangue.
+const wording = useCompetitionWording(() => (competition.value as any)?.mode);
+const unitLabel = wording.nounPluralCapitalized;
 const { data: engagements } = competition?.value?.has_likes
   ? await useFetch(`/api/v1/competitions/${slug}/engagements`)
   : { data: ref([]) };
@@ -189,7 +194,7 @@ const rankingPosition = (idx: number) => {
 
 const mappedRankByCompetition = computed(() => {
   const generalRanking = {
-    labels: ["#", labelByType.value, "Doações"],
+    labels: ["#", labelByType.value, unitLabel.value],
     contents: content?.value?.map((c, idx) => ({
       "#": rankingPosition(idx),
       [labelByType.value]: {
@@ -199,16 +204,16 @@ const mappedRankByCompetition = computed(() => {
           logo: c.logo_url,
         },
       },
-      Doações: c.donation_count,
+      [unitLabel.value]: c.donation_count,
     })),
   };
 
   const likesRanking = {
-    labels: ["#", "Doações", "Curtidas"],
+    labels: ["#", unitLabel.value, "Curtidas"],
     contents:
       engagements?.value?.map((c: any, idx: number) => ({
         "#": rankingPosition(idx),
-        Doações: c.teams.name,
+        [unitLabel.value]: c.teams.name,
         Curtidas: c.amountLikes,
       })) ?? [],
   };

--- a/pages/competition/[slug]/influence.vue
+++ b/pages/competition/[slug]/influence.vue
@@ -43,7 +43,7 @@
             {{ currentInfluenceTeamName || teamButtonLabel }}
           </ElButton>
           <span class="disclaimer-copy"
-            >As próximas doações feitas por pessoas influenciadas por você serão
+            >As próximas {{ influenceUnit }} feitas por pessoas influenciadas por você serão
             computadas para o time selecionado!</span
           >
         </div>
@@ -73,7 +73,7 @@
     </div>
     <ElDrawer
       v-model="teamDrawer"
-      title="Escolha o time para o qual as doações serão computadas"
+      :title="`Escolha o time para o qual as ${influenceUnit} serão computadas`"
       :visible="teamDrawer"
       direction="btt"
       @close="teamDrawer = false"
@@ -199,6 +199,12 @@ if (!competitionInfluence.value) {
 
 const { data: competition } = await useFetch(
   `/api/v1/competitions/${competitionSlug}`
+);
+
+// Copa participativa conta participacao, nao bolsa de sangue.
+const { noun } = useCompetitionWording(() => (competition.value as any)?.mode);
+const influenceUnit = computed(() =>
+  noun.value === "participação" ? "participações" : "doações",
 );
 
 const influencedTitle = computed(() => {

--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -105,7 +105,7 @@
               unidade.
             </span>
             <el-radio-group v-model="form.kind" size="large">
-              <el-radio-button value="donation">Sim, eu doei</el-radio-button>
+              <el-radio-button value="donation">Sim, consegui doar</el-radio-button>
               <el-radio-button value="participation">
                 Não consegui doar
               </el-radio-button>
@@ -168,7 +168,7 @@
                 </el-icon>
                 <img
                   :src="form.proof"
-                  alt="Comprovante de Doação"
+                  :alt="isParticipation ? 'Comprovante de Participação' : 'Comprovante de Doação'"
                   class="taken-image"
                 />
               </div>
@@ -565,7 +565,7 @@ async function handleSubmit(event: any) {
   } catch (error) {
     ElMessage({
       type: "error",
-      message: "Erro ao registrar doação. Por favor, tente novamente.",
+      message: `Erro ao registrar ${isParticipation.value ? "participação" : "doação"}. Por favor, tente novamente.`,
       duration: 3000,
     });
     registeringDonation.value = false;


### PR DESCRIPTION
## O que

Numa copa `mode=participation`, a UI passa a falar **participação** em vez de doação — nas telas e nos rankings, não só no formulário de registro.

| Onde | Antes | Copa participativa |
|---|---|---|
| Ranking geral (coluna) | `Doações` | `Participações` |
| Ranking de curtidas | `Doações` | `Participações` |
| Contador do topo | `TOTAL DE DOAÇÕES REALIZADAS` | `TOTAL DE PARTICIPAÇÕES REGISTRADAS` |
| CTA na página da copa | `Registrar doação` | `Registrar Participação` |
| Tela de indicação | "as próximas **doações**…" | "as próximas **participações**…" |
| `alt` do comprovante | `Comprovante de Doação` | `Comprovante de Participação` |
| Mensagem de erro | "Erro ao registrar doação" | "…registrar participação" |

Também troquei `Sim, eu doei` por **`Sim, consegui doar`** no radio de autodeclaração — casa melhor com a pergunta ("Você conseguiu doar?").

## Por que centralizado

Criei `composables/useCompetitionWording.ts` em vez de espalhar ternário por tela. Uma copa nova não deveria exigir caçar strings pelo repo, e o termo aparecia em 6 arquivos diferentes.

O `FlowGeneral` recebe o rótulo **por prop** em vez de consultar o modo da copa — o componente não precisa conhecer esse conceito, quem sabe é a página.

## Fora de escopo, deliberadamente

`legacy.vue` e `gotinha.vue` seguem com o texto antigo: o primeiro é legado e o segundo parece página de demo. Se algum dos dois ainda é usado em copa real, me avisa que eu incluo.

## Verificação

`yarn build` compila, `yarn test` 24 verdes. Vou conferir na copa de dev (`trote-solidario-yduqs-20262`) depois do merge — inclusive o ranking, que é o que você pediu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L