### PR TITLE
fix(register): toggle de autodeclaracao quebrado + full width no celular

### DIFF
--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -104,9 +104,20 @@
               algum impedimento, sua participação continua contando para a sua
               unidade.
             </span>
-            <el-radio-group v-model="form.kind" size="large">
-              <el-radio-button value="donation">Sim, consegui doar</el-radio-button>
-              <el-radio-button value="participation">
+            <!--
+              Element Plus 2.4.x usa `label` como VALOR do radio; o prop `value`
+              so existe a partir do 2.6. Com `value`, os dois botoes ficavam com
+              valor undefined e o grupo nao conseguia distingui-los: o primeiro
+              clique "funcionava", o segundo travava e a primeira opcao era
+              inalcancavel. O texto visivel continua vindo do slot.
+            -->
+            <el-radio-group
+              v-model="form.kind"
+              size="large"
+              class="kind-radio-group"
+            >
+              <el-radio-button label="donation">Sim, consegui doar</el-radio-button>
+              <el-radio-button label="participation">
                 Não consegui doar
               </el-radio-button>
             </el-radio-group>
@@ -577,6 +588,30 @@ async function handleSubmit(event: any) {
 }
 </script>
 <style scoped>
+/* O toggle de autodeclaracao ocupa a largura toda: em celular duas opcoes
+   estreitas e centralizadas sao dificeis de acertar com o dedo. */
+.kind-radio-group {
+  width: 100%;
+  display: flex;
+}
+
+.kind-radio-group :deep(.el-radio-button) {
+  flex: 1 1 0;
+  display: flex;
+}
+
+.kind-radio-group :deep(.el-radio-button__inner) {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  white-space: normal;
+  line-height: 1.2;
+  padding: 0.75rem 0.5rem;
+}
+
 .user-name-wrapper {
   width: 100%;
   display: flex;


### PR DESCRIPTION
## O bug

No toggle "Você conseguiu doar?", o primeiro clique em "Não consegui doar" parecia funcionar, o segundo travava, e **a primeira opção era impossível de selecionar**.

Causa: o `el-radio-button` do **Element Plus 2.4.3** usa **`label` como valor** do radio. O prop `value` só existe a partir do 2.6 — e eu escrevi `value`. Resultado: os dois botões ficavam com valor `undefined`, então o grupo não conseguia distingui-los.

```diff
-<el-radio-button value="donation">Sim, consegui doar</el-radio-button>
+<el-radio-button label="donation">Sim, consegui doar</el-radio-button>
```

O texto visível continua vindo do slot, então o rótulo não muda.

**Impacto real:** com `form.kind` ficando `undefined`, o endpoint recebia `kind` inválido e caía no default `"donation"` — ou seja, **quem não conseguiu doar seria registrado como doação e entraria na fila do hemocione-id**. O gate estava correto; o valor que chegava nele é que estava errado.

## Full width

O toggle passa a ocupar a largura toda, dividida igualmente entre as duas opções, com o texto quebrando em vez de estourar. Duas opções estreitas e centralizadas são difíceis de acertar com o dedo no celular.

## Como escapou

Meus testes de registro foram todos por **API**, passando `kind` direto no body — nunca pela UI. O formulário só apareceu no browser depois, quando você clicou. Testar o endpoint não testa o componente que alimenta o endpoint.

## Verificação

`yarn build` compila. Vou conferir o clique na copa de dev depois do merge, nas duas opções e em viewport de celular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L