### PR TITLE
feat(proof): aceitar qualquer subdominio hemocione em https como prova

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -76,11 +76,6 @@ export default defineNuxtConfig({
     donationsQueueUrl: process.env.DONATIONS_QUEUE_URL ?? "queue-url",
     ondeDoarApiUrl:
       process.env.ONDE_DOAR_API_URL ?? "https://ondedoar.hemocione.com.br",
-    // Hosts de onde aceitamos um proofUrl vindo por query string. Comparacao de
-    // host exato — ver utils/proofUrl.ts.
-    allowedProofHosts:
-      process.env.ALLOWED_PROOF_HOSTS ??
-      "possodoar.hemocione.com.br,possodoar.d.hemocione.com.br,cdn.hemocione.com.br",
   },
 
   routeRules: {

--- a/server/api/v1/competitions/[slug]/donations/index.post.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.post.ts
@@ -67,16 +67,10 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // proofUrl chega por query string: e o comprovante da pre-triagem, mandado
-  // pelo can-donate. Sem allowlist o campo proof viraria armazem de link
-  // arbitrario. Fora da allowlist o valor e ignorado, nao falha o registro.
-  const allowedProofHosts = String(config.allowedProofHosts ?? "")
-    .split(",")
-    .map((host) => host.trim())
-    .filter(Boolean);
-  const externalProof = isAllowedProofUrl(proofUrl, allowedProofHosts)
-    ? String(proofUrl)
-    : undefined;
+  // proofUrl chega por query string: e o comprovante da pre-triagem mandado pelo
+  // can-donate, ou uma imagem da CDN. Aceita https sob qualquer subdominio
+  // hemocione.com.br. Fora disso o valor e ignorado, nao falha o registro.
+  const externalProof = isAllowedProofUrl(proofUrl) ? String(proofUrl) : undefined;
 
   const resolvedProof = proof || externalProof;
 

--- a/utils/proofUrl.test.ts
+++ b/utils/proofUrl.test.ts
@@ -1,62 +1,49 @@
 import { describe, expect, it } from "vitest";
 import { isAllowedProofUrl } from "./proofUrl";
 
-const allowed = [
-  "possodoar.hemocione.com.br",
-  "possodoar.d.hemocione.com.br",
-  "cdn.hemocione.com.br",
-];
-
 describe("isAllowedProofUrl", () => {
-  it("aceita host allowlistado em https", () => {
-    expect(
-      isAllowedProofUrl(
-        "https://possodoar.hemocione.com.br/comprovante/abc",
-        allowed,
-      ),
-    ).toBe(true);
-    expect(isAllowedProofUrl("https://cdn.hemocione.com.br/x.jpg", allowed)).toBe(
-      true,
-    );
+  it("aceita qualquer subdominio hemocione em https", () => {
+    expect(isAllowedProofUrl("https://possodoar.hemocione.com.br/comprovante/abc")).toBe(true);
+    expect(isAllowedProofUrl("https://possodoar.d.hemocione.com.br/comprovante/abc")).toBe(true);
+    expect(isAllowedProofUrl("https://cdn.hemocione.com.br/x.jpg")).toBe(true);
+    expect(isAllowedProofUrl("https://qualquer.coisa.nova.hemocione.com.br/y")).toBe(true);
   });
 
-  it("recusa host fora da allowlist", () => {
-    expect(isAllowedProofUrl("https://evil.com/x.jpg", allowed)).toBe(false);
+  it("aceita o dominio raiz", () => {
+    expect(isAllowedProofUrl("https://hemocione.com.br/x")).toBe(true);
   });
 
-  it("recusa subdominio que apenas termina com host permitido", () => {
-    expect(
-      isAllowedProofUrl("https://cdn.hemocione.com.br.evil.com/x", allowed),
-    ).toBe(false);
+  it("aceita host em maiusculas", () => {
+    expect(isAllowedProofUrl("https://CDN.Hemocione.Com.BR/x.jpg")).toBe(true);
+  });
+
+  it("recusa dominio que apenas TERMINA com o nome — nao e subdominio", () => {
+    expect(isAllowedProofUrl("https://evil-hemocione.com.br/x")).toBe(false);
+    expect(isAllowedProofUrl("https://naohemocione.com.br/x")).toBe(false);
+  });
+
+  it("recusa dominio que usa o nosso como prefixo", () => {
+    expect(isAllowedProofUrl("https://hemocione.com.br.evil.com/x")).toBe(false);
+    expect(isAllowedProofUrl("https://cdn.hemocione.com.br.evil.com/x")).toBe(false);
   });
 
   it("recusa host permitido usado como userinfo", () => {
-    expect(
-      isAllowedProofUrl("https://cdn.hemocione.com.br@evil.com/x", allowed),
-    ).toBe(false);
+    expect(isAllowedProofUrl("https://cdn.hemocione.com.br@evil.com/x")).toBe(false);
   });
 
   it("recusa http — o comprovante e servido por https", () => {
-    expect(isAllowedProofUrl("http://cdn.hemocione.com.br/x.jpg", allowed)).toBe(
-      false,
-    );
+    expect(isAllowedProofUrl("http://cdn.hemocione.com.br/x.jpg")).toBe(false);
   });
 
   it("recusa esquemas nao-http", () => {
-    expect(isAllowedProofUrl("javascript:alert(1)", allowed)).toBe(false);
-    expect(isAllowedProofUrl("data:text/html,x", allowed)).toBe(false);
+    expect(isAllowedProofUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedProofUrl("data:text/html,x")).toBe(false);
   });
 
   it("recusa vazio, ausente e lixo", () => {
-    expect(isAllowedProofUrl(undefined, allowed)).toBe(false);
-    expect(isAllowedProofUrl(null, allowed)).toBe(false);
-    expect(isAllowedProofUrl("", allowed)).toBe(false);
-    expect(isAllowedProofUrl("not a url", allowed)).toBe(false);
-  });
-
-  it("recusa tudo quando a allowlist esta vazia", () => {
-    expect(isAllowedProofUrl("https://cdn.hemocione.com.br/x.jpg", [])).toBe(
-      false,
-    );
+    expect(isAllowedProofUrl(undefined)).toBe(false);
+    expect(isAllowedProofUrl(null)).toBe(false);
+    expect(isAllowedProofUrl("")).toBe(false);
+    expect(isAllowedProofUrl("not a url")).toBe(false);
   });
 });

--- a/utils/proofUrl.ts
+++ b/utils/proofUrl.ts
@@ -1,18 +1,20 @@
+/** Dominio raiz da Hemocione. Qualquer subdominio dele serve como prova. */
+const HEMOCIONE_ROOT_DOMAIN = "hemocione.com.br";
+
 /**
  * O proofUrl pode chegar por query string: o can-donate manda a URL do
- * comprovante de pre-triagem para quem foi reprovado e vai registrar
- * participacao. Sem allowlist, o campo proof da copa viraria armazem de link
- * arbitrario.
+ * comprovante de pre-triagem, e a CDN serve as imagens enviadas. Sem allowlist,
+ * o campo proof da copa viraria armazem de link arbitrario.
  *
- * Compara host EXATO de proposito. endsWith deixaria passar
- * "cdn.hemocione.com.br.evil.com", e userinfo
- * ("https://cdn.hemocione.com.br@evil.com") engana leitura humana.
+ * A regra e "https + qualquer coisa sob hemocione.com.br", o que cobre
+ * possodoar, possodoar.d, cdn e o que vier depois sem precisar de config.
+ *
+ * O match e na FRONTEIRA do dominio de proposito. Um endsWith cru aceitaria
+ * "evil-hemocione.com.br", e userinfo ("https://cdn.hemocione.com.br@evil.com")
+ * engana leitura humana — os dois sao recusados.
  */
-export function isAllowedProofUrl(
-  url: string | undefined | null,
-  allowedHosts: string[],
-): boolean {
-  if (!url || !allowedHosts.length) return false;
+export function isAllowedProofUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
 
   let parsed: URL;
   try {
@@ -24,5 +26,9 @@ export function isAllowedProofUrl(
   if (parsed.protocol !== "https:") return false;
   if (parsed.username || parsed.password) return false;
 
-  return allowedHosts.includes(parsed.hostname);
+  const host = parsed.hostname.toLowerCase();
+  return (
+    host === HEMOCIONE_ROOT_DOMAIN ||
+    host.endsWith(`.${HEMOCIONE_ROOT_DOMAIN}`)
+  );
 }


### PR DESCRIPTION
## O que

A allowlist de hosts fixos vira uma regra: **https + qualquer coisa sob `hemocione.com.br`**.

Cobre `possodoar`, `possodoar.d`, a **CDN das imagens** e o que vier depois, sem precisar mexer em env. A env `ALLOWED_PROOF_HOSTS` foi removida — um host novo não exige mais deploy de config.

## O cuidado que vale review

O match é na **fronteira do domínio**, não um `endsWith` cru:

```ts
host === "hemocione.com.br" || host.endsWith(".hemocione.com.br")
```

Um `endsWith("hemocione.com.br")` aceitaria **`evil-hemocione.com.br`**, que não é nosso — é registrável por qualquer um. Continua recusando:

| Entrada | Por quê |
|---|---|
| `https://evil-hemocione.com.br/x` | não é subdomínio, só termina com o nome |
| `https://cdn.hemocione.com.br.evil.com/x` | usa o nosso como prefixo |
| `https://cdn.hemocione.com.br@evil.com/x` | userinfo engana leitura humana |
| `http://cdn.hemocione.com.br/x` | não é https |

Tem teste para cada um. Host em maiúsculas é aceito (normalizado).

## Testes

`yarn test` — 25 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proof links are now consistently validated against secure Hemocione domains, including the root domain and subdomains.
  * Invalid, insecure, deceptive, or malformed links continue to be rejected without interrupting donation registration.
  * Domain matching is now case-insensitive for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->