### PR TITLE
feat(register): pular o campo de comprovante quando a prova vem por URL

### DIFF
--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -123,8 +123,33 @@
             </el-radio-group>
           </div>
 
+          <!--
+            Prova ja recebida por URL (comprovante da pre-triagem): pular o campo
+            inteiro. Pedir foto a quem acabou de ser reprovado na pre-triagem nao
+            faz sentido — ela nao tem foto de doacao para enviar, e a prova dela
+            ja esta na mao.
+          -->
+          <div
+            class="column"
+            key="proof-from-url"
+            v-if="hasExternalProof && isTeamSelected"
+          >
+            <label class="label-form">Comprovante</label>
+            <div class="external-proof">
+              <el-icon size="18"><ElIconCircleCheckFilled /></el-icon>
+              <span>
+                Comprovante da sua pré-triagem anexado.
+                <a :href="form.proofUrl" target="_blank" rel="noopener">Ver</a>
+              </span>
+            </div>
+          </div>
+
           <!-- Proof Field -->
-          <div class="column" key="proof" v-if="isTeamSelected">
+          <div
+            class="column"
+            key="proof"
+            v-if="!hasExternalProof && isTeamSelected"
+          >
             <input
               id="file-input"
               type="file"
@@ -259,7 +284,14 @@ const code = route.query.code ? String(route.query.code) : null;
 // mentir pelo query param equivale a mentir clicando.
 const initialKind =
   route.query.kind === "participation" ? "participation" : "donation";
-const externalProofUrl = route.query.proofUrl ? String(route.query.proofUrl) : "";
+// Mesma regra do servidor (utils/proofUrl.ts): https sob qualquer subdominio
+// hemocione. Sem validar aqui, um proofUrl invalido esconderia o campo de foto
+// enquanto o servidor descartaria o link — a pessoa ficaria sem poder registrar
+// nem enviar comprovante.
+const externalProofUrl = (() => {
+  const raw = route.query.proofUrl ? String(route.query.proofUrl) : "";
+  return isAllowedProofUrl(raw) ? raw : "";
+})();
 
 const uploadingImage = ref(false);
 const registeringDonation = ref(false);
@@ -366,6 +398,8 @@ const form = ref({
     ...Object.fromEntries(extraFieldsSlugs.map((slug) => [slug, ""])),
   },
 });
+
+const hasExternalProof = computed(() => Boolean(form.value.proofUrl));
 
 const institutions = computed(() =>
   sortBy(
@@ -588,6 +622,22 @@ async function handleSubmit(event: any) {
 }
 </script>
 <style scoped>
+.external-proof {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #dbdde0;
+  border-radius: 0.5rem;
+  color: #52575c;
+  font-size: 0.9rem;
+}
+
+.external-proof a {
+  color: var(--hemo-color-primary);
+  font-weight: 600;
+}
+
 /* O toggle de autodeclaracao ocupa a largura toda: em celular duas opcoes
    estreitas e centralizadas sao dificeis de acertar com o dedo. */
 .kind-radio-group {


### PR DESCRIPTION
## O que

Quando o registro é aberto com `?proofUrl=…`, o campo de upload de comprovante **não é renderizado**. No lugar aparece a confirmação de que o comprovante da pré-triagem foi anexado, com link para abrir.

## Por que

Quem chega com `proofUrl` vem do fluxo de **reprovação na pré-triagem** — não tem foto de doação para enviar, porque não doou. Pedir comprovante nesse caso é pedir algo que a pessoa não pode dar, e o campo só gerava dúvida ("preciso mandar foto de quê?").

## O cuidado que vale review

O `proofUrl` passa pela **mesma validação do servidor** (`isAllowedProofUrl`) antes de decidir esconder o campo.

Sem isso haveria um beco sem saída: um `proofUrl` inválido (ou de host não permitido) esconderia o upload, o servidor descartaria o link, e com `mandatory_proof: true` — que é o caso da copa `yduqs-2026` em produção — o registro voltaria 400 **sem a pessoa ter como enviar nada**.

Reusar a função em vez de reescrever a regra no client evita que as duas divirjam com o tempo.

## Verificação

`yarn build` compila, `yarn test` 25 verdes. Vou validar em dev nos dois caminhos: com `proofUrl` válido (campo escondido, registro completa) e com `proofUrl` inválido (campo aparece normalmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration forms now accept externally supplied proof links.
  * Valid proof links are confirmed with a clickable preview.
  * External proof links can satisfy mandatory proof requirements.

* **Bug Fixes**
  * Invalid proof links are ignored to prevent unusable submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->