### PR TITLE
fix(register): pedir localizacao ao abrir a pagina e nunca travar o submit

### DIFF
--- a/pages/competition/[slug]/register.vue
+++ b/pages/competition/[slug]/register.vue
@@ -552,21 +552,38 @@ const extraFieldsResponse = computed(() => {
 
 const GEO_TIMEOUT_MS = 8000;
 
+type GeoResult =
+  | { lat: number; lng: number; accuracy?: number }
+  | { reason: string };
+
 /**
- * Geolocalizacao best-effort. NUNCA rejeita: geo e enriquecimento de prova, nao
- * pre-requisito de registro.
+ * Resultado da geolocalizacao, resolvido em background.
+ *
+ * Comeca como "pending": se a pessoa nunca responder ao prompt, o registro sai
+ * com esse motivo em vez de esperar por ela.
+ */
+const geoResult = ref<GeoResult>({ reason: "pending" });
+
+/**
+ * Geolocalizacao best-effort. NUNCA rejeita e NUNCA prende o fluxo: geo e
+ * enriquecimento de prova, nao pre-requisito de registro.
+ *
+ * O timeout do getCurrentPosition NAO cobre o tempo em que o prompt de
+ * permissao fica aberto — se a pessoa ignora o prompt, o callback simplesmente
+ * nunca dispara. Por isso ha um teto de tempo proprio, por Promise.race: sem
+ * ele o await ficava pendurado para sempre e o botao de registrar travava em
+ * loading, que foi o bug relatado.
  *
  * Dentro do app, o iframe precisa de allow="geolocation" e o build nativo
- * precisa das permissoes de plataforma. Em app antigo isso simplesmente nao vem
- * — e o registro tem que funcionar do mesmo jeito.
+ * precisa das permissoes de plataforma. Em app antigo isso nao vem — e o
+ * registro tem que funcionar do mesmo jeito.
  */
-async function captureGeo(): Promise<
-  { lat: number; lng: number; accuracy?: number } | { reason: string }
-> {
+function captureGeo(): Promise<GeoResult> {
   if (!import.meta.client || !navigator.geolocation) {
-    return { reason: "unavailable" };
+    return Promise.resolve({ reason: "unavailable" });
   }
-  return new Promise((resolve) => {
+
+  const doBrowser = new Promise<GeoResult>((resolve) => {
     navigator.geolocation.getCurrentPosition(
       (pos) =>
         resolve({
@@ -581,7 +598,36 @@ async function captureGeo(): Promise<
       { timeout: GEO_TIMEOUT_MS, maximumAge: 60_000 },
     );
   });
+
+  const tetoDeTempo = new Promise<GeoResult>((resolve) =>
+    setTimeout(() => resolve({ reason: "timeout" }), GEO_TIMEOUT_MS),
+  );
+
+  return Promise.race([doBrowser, tetoDeTempo]);
 }
+
+/**
+ * Dispara a captura assim que a pagina abre, sem await: o prompt aparece
+ * enquanto a pessoa preenche o formulario, e nao no meio do submit. Se ela
+ * responder depois, o resultado e aproveitado; se nunca responder, o registro
+ * sai com reason "pending".
+ */
+function iniciarCapturaDeGeo() {
+  if (!isParticipation.value) return;
+  captureGeo().then((resultado) => {
+    geoResult.value = resultado;
+  });
+}
+
+onMounted(iniciarCapturaDeGeo);
+
+// Copa carregada depois do mount (ou time escolhido antes de sabermos o modo):
+// tenta de novo quando o modo participativo aparecer.
+watch(isParticipation, (participativa) => {
+  if (participativa && "reason" in geoResult.value && geoResult.value.reason === "pending") {
+    iniciarCapturaDeGeo();
+  }
+});
 
 async function handleSubmit(event: any) {
   registeringDonation.value = true;
@@ -591,7 +637,8 @@ async function handleSubmit(event: any) {
   }
   const influenceId = influencedBy?.value?.id;
 
-  const geo = isParticipation.value ? await captureGeo() : undefined;
+  // Usa o que a captura em background ja tiver resolvido. Nao espera.
+  const geo = isParticipation.value ? geoResult.value : undefined;
 
   const payload = {
     competitionTeamId: form.value.competitionTeamId,

--- a/utils/geo.test.ts
+++ b/utils/geo.test.ts
@@ -71,6 +71,13 @@ describe("resolveGeoValidation", () => {
     });
   });
 
+  it("aceita 'pending' — registro antes de a pessoa responder ao prompt", () => {
+    expect(resolveGeoValidation({ coords: null, reason: "pending" })).toEqual({
+      geoValidated: false,
+      reason: "pending",
+    });
+  });
+
   it("usa 'unavailable' como motivo padrao", () => {
     expect(resolveGeoValidation({ coords: null })).toEqual({
       geoValidated: false,

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -2,7 +2,10 @@ export type GeoFailureReason =
   | "denied"
   | "timeout"
   | "unavailable"
-  | "no-point-nearby";
+  | "no-point-nearby"
+  // A pessoa registrou antes de responder ao prompt de permissao. A captura
+  // roda em background e nunca prende o submit — ver register.vue.
+  | "pending";
 
 export type ProofMetadata = {
   lat?: number;


### PR DESCRIPTION
## O bug

Reportado pelo Lucas: *"no fluxo de aprovado quando não há coleta externa, não liberei minha loc e travou"*.

## A causa

O `timeout` do `getCurrentPosition` **não cobre o tempo em que o prompt de permissão fica aberto** — pela spec ele só começa a contar depois de a permissão ser resolvida. Se a pessoa ignora o prompt (nem permite, nem nega), o callback **nunca** dispara, os 8s nunca vencem, e o `await captureGeo()` dentro do `handleSubmit` fica pendurado para sempre. O botão fica em loading e nada acontece.

Eu tinha escrito no PR original que a geo "nunca bloqueia". Bloqueava — só não no caminho que eu testei. Nos meus testes eu **negava** a permissão, e negar dispara o callback de erro na hora. Ignorar o prompt é o caso que trava, e é o mais natural pra quem está em dúvida.

## As duas mudanças

**1. A captura começa no `mount`, sem `await`.** O prompt aparece enquanto a pessoa preenche o formulário, não no meio do submit. Um `watch` re-tenta caso o modo participativo só seja conhecido depois de a copa carregar.

**2. Teto de tempo próprio, via `Promise.race`**, independente do timeout do browser. Sem isso não há nada que salve de um prompt ignorado.

O submit passa a usar o que a captura já resolveu, sem esperar. Se a pessoa registrar antes de responder, o registro sai com `reason: "pending"` — motivo novo, agora no tipo e com teste.

## Verificação

`yarn build` compila, `yarn test` 26 verdes. Vou validar em dev o caso que quebrava: abrir o registro, **ignorar** o prompt, e confirmar que o submit completa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPjcdHFAWtbjz3fBhqhX7L