### PR TITLE
feat(backoffice): listar doações de uma competição + fix do ranking

### DIFF
--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -1,0 +1,70 @@
+import { assertSecretAuth } from "~/server/services/auth";
+import { listCompetitionDonations } from "~/server/services/donationService";
+import { getCompetitionBySlug } from "~/server/services/competitionService";
+
+const STATUS_VALIDOS = ["pending", "approved", "rejected"] as const;
+const KINDS_VALIDOS = ["donation", "participation"] as const;
+
+const TAKE_PADRAO = 50;
+const TAKE_MAXIMO = 200;
+
+function lerInteiro(valor: unknown, padrao: number, minimo: number, maximo: number) {
+  if (valor === undefined || valor === "") return padrao;
+
+  const numero = Number(valor);
+  if (!Number.isInteger(numero)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid pagination",
+    });
+  }
+
+  return Math.min(Math.max(numero, minimo), maximo);
+}
+
+/**
+ * Lista as doacoes de uma competicao.
+ *
+ * Existia como moderar (PUT .../donations/:id/status) sem como descobrir o que
+ * moderar: nao havia nenhum GET que devolvesse os ids pendentes, so o do
+ * proprio usuario. Sem esta rota, moderar pela API exige consultar o Postgres
+ * na mao.
+ */
+export default defineEventHandler(async (event) => {
+  assertSecretAuth(event);
+
+  const slug = String(getRouterParam(event, "slug"));
+  const competition = await getCompetitionBySlug(slug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
+
+  const query = getQuery(event);
+
+  const status = query.status ? String(query.status) : undefined;
+  if (status && !STATUS_VALIDOS.includes(status as (typeof STATUS_VALIDOS)[number])) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid status",
+    });
+  }
+
+  const kind = query.kind ? String(query.kind) : undefined;
+  if (kind && !KINDS_VALIDOS.includes(kind as (typeof KINDS_VALIDOS)[number])) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid kind",
+    });
+  }
+
+  return await listCompetitionDonations({
+    competitionId: competition.id,
+    ...(status ? { status: status as (typeof STATUS_VALIDOS)[number] } : {}),
+    ...(kind ? { kind: kind as (typeof KINDS_VALIDOS)[number] } : {}),
+    take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
+    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+  });
+});

--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -7,6 +7,11 @@ const KINDS_VALIDOS = ["donation", "participation"] as const;
 
 const TAKE_PADRAO = 50;
 const TAKE_MAXIMO = 200;
+// Offset tem teto porque o Postgres varre e descarta tudo antes do OFFSET: um
+// valor arbitrario faz o banco trabalhar a competicao inteira para devolver uma
+// pagina vazia. 100 mil, com take de 200, da 500 paginas - alem disso, o caso de
+// uso pede filtro, nao paginacao mais profunda.
+const SKIP_MAXIMO = 100_000;
 
 function lerInteiro(valor: unknown, padrao: number, minimo: number, maximo: number) {
   if (valor === undefined || valor === "") return padrao;
@@ -65,6 +70,6 @@ export default defineEventHandler(async (event) => {
     ...(status ? { status: status as (typeof STATUS_VALIDOS)[number] } : {}),
     ...(kind ? { kind: kind as (typeof KINDS_VALIDOS)[number] } : {}),
     take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
-    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+    skip: lerInteiro(query.skip, 0, 0, SKIP_MAXIMO),
   });
 });

--- a/server/api/v1/competitions/[slug]/rankings.get.ts
+++ b/server/api/v1/competitions/[slug]/rankings.get.ts
@@ -1,14 +1,26 @@
-import { getCompetitionRanking } from "~/server/services/competitionService";
+import {
+  getCompetitionBySlug,
+  getCompetitionRanking,
+} from "~/server/services/competitionService";
 
+/**
+ * Ranking dos times de uma competicao.
+ *
+ * O parametro da rota chama-se `slug`, mas este handler lia `id` — sempre
+ * undefined, entao `Number(undefined)` era NaN e a rota lancava em 100% das
+ * chamadas. Nenhuma pagina do front a consumia, o que explica o bug ter
+ * passado sem ninguem notar.
+ */
 export default defineEventHandler(async (event) => {
-  
-    const id = getRouterParam(event, 'id');
+  const slug = String(getRouterParam(event, "slug"));
 
-    // Check if id is a number
-    if (isNaN(Number(id))) {
-        throw new Error('Invalid competition id');
-    }
+  const competition = await getCompetitionBySlug(slug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
 
-    const ranking = await getCompetitionRanking(Number(id));
-    return ranking;
+  return await getCompetitionRanking(competition.id);
 });

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -142,3 +142,57 @@ export const updateDonationStatus = async (data: {
     },
   });
 }
+
+export const listCompetitionDonations = async (data: {
+  competitionId: number;
+  status?: "pending" | "approved" | "rejected";
+  kind?: "donation" | "participation";
+  take: number;
+  skip: number;
+}) => {
+  const { competitionId, status, kind, take, skip } = data;
+  const where = {
+    competitionId,
+    ...(status ? { status } : {}),
+    ...(kind ? { kind } : {}),
+  };
+
+  // A contagem usa o mesmo filtro da pagina: sem isso, quem pagina nao sabe
+  // quantas doacoes ainda faltam moderar.
+  const [total, items] = await Promise.all([
+    dbClient.donations.count({ where }),
+    dbClient.donations.findMany({
+      where,
+      select: {
+        id: true,
+        user_name: true,
+        user_email: true,
+        hemocioneID: true,
+        competitionTeamId: true,
+        competitionId: true,
+        kind: true,
+        status: true,
+        proof: true,
+        extraFields: true,
+        donationDate: true,
+        createdAt: true,
+        updatedAt: true,
+        // O nome do time vive em `teams`; `competitionTeams` e a ligacao
+        // entre time e competicao. Quem modera precisa ver o nome.
+        competitionTeams: {
+          select: {
+            id: true,
+            teams: { select: { id: true, name: true } },
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+      take,
+      skip,
+    }),
+  ]);
+
+  return { total, items };
+};

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -186,9 +186,10 @@ export const listCompetitionDonations = async (data: {
           },
         },
       },
-      orderBy: {
-        createdAt: "desc",
-      },
+      // `id` como desempate porque `createdAt` nao e unico: doacoes gravadas no
+      // mesmo instante nao tem ordem relativa definida, e sem chave estavel uma
+      // linha pode repetir numa pagina e faltar na seguinte.
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take,
       skip,
     }),


### PR DESCRIPTION
## Por quê

Surgiu ao construir o [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp), um proxy MCP dos endpoints de backoffice: ao catalogar as rotas de moderação da Copa, os dois problemas abaixo apareceram ao exercitá-las de verdade contra o ambiente de dev.

### 1. Não havia como descobrir o que moderar

Existe `PUT /api/v1/competitions/:slug/donations/:donationId/status` para aprovar ou rejeitar uma doação, mas **nenhum `GET` que devolvesse os `donationId` pendentes** — o único `GET` de doação é o `mine` do próprio usuário. Na prática, moderar pela API era impossível sem abrir o Postgres na mão.

Este PR adiciona `GET /api/v1/competitions/:slug/donations`, protegido por `assertSecretAuth` como as demais rotas de backoffice:

- filtros opcionais `status` (`pending`/`approved`/`rejected`) e `kind` (`donation`/`participation`), com 400 em valor inválido em vez de ignorar silenciosamente;
- paginação `take` (padrão 50, teto 200) e `skip`;
- resposta `{ total, items }`, em que `total` usa **o mesmo filtro** da página — sem isso quem pagina não sabe quantas doações ainda faltam;
- o nome do time vem de `teams` através de `competitionTeams` (esta última é só a ligação time↔competição e não tem `name`).

### 2. `GET /api/v1/competitions/:slug/rankings` respondia 500 em 100% das chamadas

O handler lia `getRouterParam(event, "id")`, mas o parâmetro da rota chama-se `slug`. Logo `id` era sempre `undefined`, `Number(undefined)` dava `NaN` e a rota lançava `Invalid competition id` **sempre**. Nenhuma página do front consome essa rota, o que explica o bug ter passado sem ninguém notar.

Evidência, contra o ambiente de dev, antes do fix:

```
copa__ranking_da_competicao   UPSTREAM 500   {"url":"/api/v1/competitions/sangue-sp/rankings","statusCode":500,...}
```

Agora resolve a competição pelo slug e responde 404 quando ela não existe. A rota segue pública, como era.

## Verificação

`vue-tsc --noEmit` no repo acusa 15 erros de tipo, **todos pré-existentes** (`nuxt.config.ts`, `pages/index.vue`, e os `donation_approved` em arquivos não tocados aqui). Nenhum erro nos três arquivos deste PR:

```
$ npx vue-tsc --noEmit 2>&1 | grep -E "donations/index.get|rankings.get|donationService"
(vazio)
```

O build completo não pôde ser rodado localmente porque `nuxt-bugsnag` exige `BUGSNAG_API_KEY` e tenta subir sourcemap (401 com chave falsa) — o CI cobre isso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to list competition donations.
  * Added filtering by donation status and type.
  * Added pagination support with validated limits.
  * Competition rankings can now be retrieved using the competition slug.
  * Added a clear not-found response for invalid competitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->