### PR TITLE
fix(backoffice): resolver competição não publicada nas rotas de doação

### DIFF
--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -1,6 +1,6 @@
 import { assertSecretAuth } from "~/server/services/auth";
 import { updateDonationStatus } from "~/server/services/donationService";
-import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { getCompetitionBySlugForBackoffice } from "~/server/services/competitionService";
 import { waitUntil } from '@vercel/functions';
 import { callWebhook } from "~/server/services/webhookService";
 
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
   });
 
   const competitionSlug = String(getRouterParam(event, 'slug'));
-  const competition = await getCompetitionBySlug(competitionSlug);
+  const competition = await getCompetitionBySlugForBackoffice(competitionSlug);
   if (!competition) {
     throw createError({
       statusCode: 404,

--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -1,6 +1,6 @@
 import { assertSecretAuth } from "~/server/services/auth";
 import { listCompetitionDonations } from "~/server/services/donationService";
-import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { getCompetitionBySlugForBackoffice } from "~/server/services/competitionService";
 
 const STATUS_VALIDOS = ["pending", "approved", "rejected"] as const;
 const KINDS_VALIDOS = ["donation", "participation"] as const;
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
 
   const slug = String(getRouterParam(event, "slug"));
-  const competition = await getCompetitionBySlug(slug);
+  const competition = await getCompetitionBySlugForBackoffice(slug);
   if (!competition) {
     throw createError({
       statusCode: 404,

--- a/server/services/competitionService.ts
+++ b/server/services/competitionService.ts
@@ -111,6 +111,22 @@ export const getCompetitionBySlug = async (slug: string) => {
   return competition;
 };
 
+/**
+ * Resolve a competicao por slug SEM filtrar por publicacao.
+ *
+ * `getCompetitionBySlug` exige `published: true`, o que e correto para as rotas
+ * publicas: rascunho nao deve aparecer. Mas as rotas de backoffice precisam
+ * operar justamente a competicao que ainda nao foi publicada - configurar e
+ * conferir antes de publicar e o fluxo normal de quem organiza a copa.
+ *
+ * Use somente em rota protegida por `assertSecretAuth`.
+ */
+export const getCompetitionBySlugForBackoffice = async (slug: string) => {
+  return await dbClient.competitions.findUnique({
+    where: { slug },
+  });
+};
+
 export const getCompetition = async (id: number) => {
   const competition = await dbClient.$queryRaw`SELECT
     id,


### PR DESCRIPTION
## Como apareceu

Exercitando o ciclo completo de uma competição pelo [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra dev:

```
criar_competicao        -> 200  slug=validacao-mcp-despublicada
listar_doacoes (mesma)  -> 404  Competition not found     ← ?
listar_competicoes?includeUnpublished=true -> encontra ela normalmente
```

A competição existe, aparece na listagem com `includeUnpublished`, aceita `PUT` de edição, aceita `teams/set`, aceita `publish` — mas listar as doações dela responde 404.

## Causa

`getCompetitionBySlugPromise` filtra por publicação:

```ts
return dbClient.competitions.findUnique({
  where: { slug, published: true },   // ← aqui
  ...
```

Isso é **correto para as rotas públicas**: rascunho não deve aparecer para quem visita. O problema é que as duas rotas de doação protegidas por `assertSecretAuth` usavam a mesma função:

- `GET /api/v1/competitions/:slug/donations` — listar para moderar
- `PUT /api/v1/competitions/:slug/donations/:donationId/status` — moderar

Ou seja, o backoffice não conseguia operar exatamente a competição que ainda está sendo configurada. Como uma competição **nasce despublicada** (`POST /competitions` não publica), o fluxo natural — criar, configurar, conferir, publicar — ficava sem os passos de conferência.

## O que muda

`getCompetitionBySlugForBackoffice` resolve por slug sem filtrar publicação, e é usada **somente** nessas duas rotas, ambas atrás de `assertSecretAuth`. As rotas públicas (`GET /competitions/:slug`, `rankings`, `influence`, `donations/mine`) seguem com `getCompetitionBySlug` e continuam não expondo rascunho.

## Verificação

`vue-tsc --noEmit` mantém o baseline de **15** erros pré-existentes do repo. Os dois que aparecem em `status/index.put.ts` (linhas 42-43, `Property 'donation_approved' does not exist on type ... JsonObject`) já estavam lá antes deste PR, nas mesmas linhas — são de tipagem do campo `Json` do Prisma, não do import trocado aqui.

Deixei em dev a competição de teste `validacao-mcp-despublicada` **despublicada** (invisível ao público). Não há `DELETE` de competição na API — se preferir limpar, é pelo banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Back-office donation management can now access competitions that have not yet been published.
  * Donation listings and status updates continue to support existing validation, authentication, pagination, and webhook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->