### PR TITLE
release: backoffice de doações da copa + fixes de ranking e rascunho

### DIFF
--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -8,6 +8,12 @@ export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
 
   const donationId = Number(getRouterParam(event, 'donationId'));
+  if (!Number.isInteger(donationId)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid donationId",
+    });
+  }
 
   const body = await readBody(event);
   const { status } = body
@@ -25,17 +31,30 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const updatedDonation = await updateDonationStatus({
-    donationId,
-    status,
-  });
-
+  // A competicao da rota e resolvida ANTES da mutacao. Na ordem anterior, a
+  // doacao era alterada e so depois o slug era conferido: um slug inexistente
+  // mudava o dado e devolvia 404, e um slug de outra competicao escolhia o
+  // webhook errado.
   const competitionSlug = String(getRouterParam(event, 'slug'));
   const competition = await getCompetitionBySlugForBackoffice(competitionSlug);
   if (!competition) {
     throw createError({
       statusCode: 404,
       statusMessage: "Competition not found"
+    });
+  }
+
+  const updatedDonation = await updateDonationStatus({
+    donationId,
+    competitionId: competition.id,
+    status,
+  });
+
+  // Doacao inexistente ou pertencente a outra competicao: nada foi alterado.
+  if (!updatedDonation) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Donation not found in this competition"
     });
   }
 

--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -1,6 +1,6 @@
 import { assertSecretAuth } from "~/server/services/auth";
 import { updateDonationStatus } from "~/server/services/donationService";
-import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { getCompetitionBySlugForBackoffice } from "~/server/services/competitionService";
 import { waitUntil } from '@vercel/functions';
 import { callWebhook } from "~/server/services/webhookService";
 
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
   });
 
   const competitionSlug = String(getRouterParam(event, 'slug'));
-  const competition = await getCompetitionBySlug(competitionSlug);
+  const competition = await getCompetitionBySlugForBackoffice(competitionSlug);
   if (!competition) {
     throw createError({
       statusCode: 404,

--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -1,0 +1,70 @@
+import { assertSecretAuth } from "~/server/services/auth";
+import { listCompetitionDonations } from "~/server/services/donationService";
+import { getCompetitionBySlug } from "~/server/services/competitionService";
+
+const STATUS_VALIDOS = ["pending", "approved", "rejected"] as const;
+const KINDS_VALIDOS = ["donation", "participation"] as const;
+
+const TAKE_PADRAO = 50;
+const TAKE_MAXIMO = 200;
+
+function lerInteiro(valor: unknown, padrao: number, minimo: number, maximo: number) {
+  if (valor === undefined || valor === "") return padrao;
+
+  const numero = Number(valor);
+  if (!Number.isInteger(numero)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid pagination",
+    });
+  }
+
+  return Math.min(Math.max(numero, minimo), maximo);
+}
+
+/**
+ * Lista as doacoes de uma competicao.
+ *
+ * Existia como moderar (PUT .../donations/:id/status) sem como descobrir o que
+ * moderar: nao havia nenhum GET que devolvesse os ids pendentes, so o do
+ * proprio usuario. Sem esta rota, moderar pela API exige consultar o Postgres
+ * na mao.
+ */
+export default defineEventHandler(async (event) => {
+  assertSecretAuth(event);
+
+  const slug = String(getRouterParam(event, "slug"));
+  const competition = await getCompetitionBySlug(slug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
+
+  const query = getQuery(event);
+
+  const status = query.status ? String(query.status) : undefined;
+  if (status && !STATUS_VALIDOS.includes(status as (typeof STATUS_VALIDOS)[number])) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid status",
+    });
+  }
+
+  const kind = query.kind ? String(query.kind) : undefined;
+  if (kind && !KINDS_VALIDOS.includes(kind as (typeof KINDS_VALIDOS)[number])) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid kind",
+    });
+  }
+
+  return await listCompetitionDonations({
+    competitionId: competition.id,
+    ...(status ? { status: status as (typeof STATUS_VALIDOS)[number] } : {}),
+    ...(kind ? { kind: kind as (typeof KINDS_VALIDOS)[number] } : {}),
+    take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
+    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+  });
+});

--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -1,6 +1,6 @@
 import { assertSecretAuth } from "~/server/services/auth";
 import { listCompetitionDonations } from "~/server/services/donationService";
-import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { getCompetitionBySlugForBackoffice } from "~/server/services/competitionService";
 
 const STATUS_VALIDOS = ["pending", "approved", "rejected"] as const;
 const KINDS_VALIDOS = ["donation", "participation"] as const;
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
 
   const slug = String(getRouterParam(event, "slug"));
-  const competition = await getCompetitionBySlug(slug);
+  const competition = await getCompetitionBySlugForBackoffice(slug);
   if (!competition) {
     throw createError({
       statusCode: 404,

--- a/server/api/v1/competitions/[slug]/donations/index.get.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.get.ts
@@ -7,6 +7,11 @@ const KINDS_VALIDOS = ["donation", "participation"] as const;
 
 const TAKE_PADRAO = 50;
 const TAKE_MAXIMO = 200;
+// Offset tem teto porque o Postgres varre e descarta tudo antes do OFFSET: um
+// valor arbitrario faz o banco trabalhar a competicao inteira para devolver uma
+// pagina vazia. 100 mil, com take de 200, da 500 paginas - alem disso, o caso de
+// uso pede filtro, nao paginacao mais profunda.
+const SKIP_MAXIMO = 100_000;
 
 function lerInteiro(valor: unknown, padrao: number, minimo: number, maximo: number) {
   if (valor === undefined || valor === "") return padrao;
@@ -65,6 +70,6 @@ export default defineEventHandler(async (event) => {
     ...(status ? { status: status as (typeof STATUS_VALIDOS)[number] } : {}),
     ...(kind ? { kind: kind as (typeof KINDS_VALIDOS)[number] } : {}),
     take: lerInteiro(query.take, TAKE_PADRAO, 1, TAKE_MAXIMO),
-    skip: lerInteiro(query.skip, 0, 0, Number.MAX_SAFE_INTEGER),
+    skip: lerInteiro(query.skip, 0, 0, SKIP_MAXIMO),
   });
 });

--- a/server/api/v1/competitions/[slug]/rankings.get.ts
+++ b/server/api/v1/competitions/[slug]/rankings.get.ts
@@ -1,14 +1,26 @@
-import { getCompetitionRanking } from "~/server/services/competitionService";
+import {
+  getCompetitionBySlug,
+  getCompetitionRanking,
+} from "~/server/services/competitionService";
 
+/**
+ * Ranking dos times de uma competicao.
+ *
+ * O parametro da rota chama-se `slug`, mas este handler lia `id` — sempre
+ * undefined, entao `Number(undefined)` era NaN e a rota lancava em 100% das
+ * chamadas. Nenhuma pagina do front a consumia, o que explica o bug ter
+ * passado sem ninguem notar.
+ */
 export default defineEventHandler(async (event) => {
-  
-    const id = getRouterParam(event, 'id');
+  const slug = String(getRouterParam(event, "slug"));
 
-    // Check if id is a number
-    if (isNaN(Number(id))) {
-        throw new Error('Invalid competition id');
-    }
+  const competition = await getCompetitionBySlug(slug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
 
-    const ranking = await getCompetitionRanking(Number(id));
-    return ranking;
+  return await getCompetitionRanking(competition.id);
 });

--- a/server/services/competitionService.ts
+++ b/server/services/competitionService.ts
@@ -111,6 +111,22 @@ export const getCompetitionBySlug = async (slug: string) => {
   return competition;
 };
 
+/**
+ * Resolve a competicao por slug SEM filtrar por publicacao.
+ *
+ * `getCompetitionBySlug` exige `published: true`, o que e correto para as rotas
+ * publicas: rascunho nao deve aparecer. Mas as rotas de backoffice precisam
+ * operar justamente a competicao que ainda nao foi publicada - configurar e
+ * conferir antes de publicar e o fluxo normal de quem organiza a copa.
+ *
+ * Use somente em rota protegida por `assertSecretAuth`.
+ */
+export const getCompetitionBySlugForBackoffice = async (slug: string) => {
+  return await dbClient.competitions.findUnique({
+    where: { slug },
+  });
+};
+
 export const getCompetition = async (id: number) => {
   const competition = await dbClient.$queryRaw`SELECT
     id,

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -142,3 +142,57 @@ export const updateDonationStatus = async (data: {
     },
   });
 }
+
+export const listCompetitionDonations = async (data: {
+  competitionId: number;
+  status?: "pending" | "approved" | "rejected";
+  kind?: "donation" | "participation";
+  take: number;
+  skip: number;
+}) => {
+  const { competitionId, status, kind, take, skip } = data;
+  const where = {
+    competitionId,
+    ...(status ? { status } : {}),
+    ...(kind ? { kind } : {}),
+  };
+
+  // A contagem usa o mesmo filtro da pagina: sem isso, quem pagina nao sabe
+  // quantas doacoes ainda faltam moderar.
+  const [total, items] = await Promise.all([
+    dbClient.donations.count({ where }),
+    dbClient.donations.findMany({
+      where,
+      select: {
+        id: true,
+        user_name: true,
+        user_email: true,
+        hemocioneID: true,
+        competitionTeamId: true,
+        competitionId: true,
+        kind: true,
+        status: true,
+        proof: true,
+        extraFields: true,
+        donationDate: true,
+        createdAt: true,
+        updatedAt: true,
+        // O nome do time vive em `teams`; `competitionTeams` e a ligacao
+        // entre time e competicao. Quem modera precisa ver o nome.
+        competitionTeams: {
+          select: {
+            id: true,
+            teams: { select: { id: true, name: true } },
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+      take,
+      skip,
+    }),
+  ]);
+
+  return { total, items };
+};

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -130,15 +130,29 @@ export const getCompetitionUserDonations = async (data: {
 
 export const updateDonationStatus = async (data: {
   donationId: number;
+  competitionId: number;
   status: "pending" | "approved" | "rejected";
 }) => {
-  const { donationId, status } = data;
-  return await dbClient.donations.update({
+  const { donationId, competitionId, status } = data;
+
+  // O update e restrito a competicao da rota: sem isso, qualquer slug valido
+  // moderava doacao de qualquer competicao, e um slug de outra competicao
+  // selecionava o webhook errado.
+  const { count } = await dbClient.donations.updateMany({
     where: {
       id: donationId,
+      competitionId,
     },
     data: {
       status,
+    },
+  });
+
+  if (count === 0) return null;
+
+  return await dbClient.donations.findUnique({
+    where: {
+      id: donationId,
     },
   });
 }

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -186,9 +186,10 @@ export const listCompetitionDonations = async (data: {
           },
         },
       },
-      orderBy: {
-        createdAt: "desc",
-      },
+      // `id` como desempate porque `createdAt` nao e unico: doacoes gravadas no
+      // mesmo instante nao tem ordem relativa definida, e sem chave estavel uma
+      // linha pode repetir numa pagina e faltar na seguinte.
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take,
       skip,
     }),


### PR DESCRIPTION
Promove para `main` o que já está validado em dev. São os PRs #60 e #61.

| O que vai | Por que importa |
|---|---|
| `GET /api/v1/competitions/:slug/donations` | Havia como **moderar** uma doação e nenhum `GET` que devolvesse as pendentes. Moderar pela API exigia abrir o Postgres na mão. |
| Fix de `rankings.get.ts` | Lia `getRouterParam(event, "id")` numa rota `:slug` — `NaN` sempre, e a rota respondia **500 em 100% das chamadas**. Nenhuma página do front a consome, o que explica ter passado. |
| Offset com teto e ordem estável | `skip` aceitava qualquer inteiro (e `MAX_SAFE_INTEGER` excede o `Int` do Prisma); a ordem só por `createdAt`, que não é único, podia repetir ou perder linhas entre páginas. |
| Backoffice resolve competição não publicada | As rotas de doação usavam `getCompetitionBySlug`, que exige `published: true` — davam 404 justamente na competição que o organizador está configurando. As rotas públicas seguem sem expor rascunho. |

## Validação em dev

Exercitado pelo [hemocione-mcp](https://github.com/Hemocione/hemocione-mcp) contra `copa.d.hemocione.com.br`, com o ciclo completo: criar → editar → definir times → publicar → despublicar, mais leitura de doações, ranking, influências e instituições. Os endpoints novos foram testados também no preview da Vercel de cada PR, incluindo os casos de erro (`status`/`kind` inválido → 400, competição inexistente → 404, `skip` gigante → 200 sem estourar).

CodeRabbit revisou os dois PRs; os três findings acionáveis (offset sem teto, ordem sem desempate, escopo do rascunho) foram aplicados antes do merge em develop.

## Nota

`main` tem 5 commits de release que `develop` não tem — o merge preserva os dois lados, como nos PRs #48 e #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a protected endpoint for retrieving competition donations with status, type, and pagination filters.
  * Donation results include related donation and team details, ordered from newest to oldest.
  * Competition rankings now resolve competitions by slug.
  * Backoffice workflows can access unpublished competitions when managing donation statuses.

* **Bug Fixes**
  * Improved competition validation and not-found handling for donation and ranking requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->