### PR TITLE
fix(backoffice): vincular a moderação de doação à competição da rota

### DIFF
--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -8,6 +8,12 @@ export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
 
   const donationId = Number(getRouterParam(event, 'donationId'));
+  if (!Number.isInteger(donationId)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request - Invalid donationId",
+    });
+  }
 
   const body = await readBody(event);
   const { status } = body
@@ -25,17 +31,30 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const updatedDonation = await updateDonationStatus({
-    donationId,
-    status,
-  });
-
+  // A competicao da rota e resolvida ANTES da mutacao. Na ordem anterior, a
+  // doacao era alterada e so depois o slug era conferido: um slug inexistente
+  // mudava o dado e devolvia 404, e um slug de outra competicao escolhia o
+  // webhook errado.
   const competitionSlug = String(getRouterParam(event, 'slug'));
   const competition = await getCompetitionBySlugForBackoffice(competitionSlug);
   if (!competition) {
     throw createError({
       statusCode: 404,
       statusMessage: "Competition not found"
+    });
+  }
+
+  const updatedDonation = await updateDonationStatus({
+    donationId,
+    competitionId: competition.id,
+    status,
+  });
+
+  // Doacao inexistente ou pertencente a outra competicao: nada foi alterado.
+  if (!updatedDonation) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Donation not found in this competition"
     });
   }
 

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -130,15 +130,29 @@ export const getCompetitionUserDonations = async (data: {
 
 export const updateDonationStatus = async (data: {
   donationId: number;
+  competitionId: number;
   status: "pending" | "approved" | "rejected";
 }) => {
-  const { donationId, status } = data;
-  return await dbClient.donations.update({
+  const { donationId, competitionId, status } = data;
+
+  // O update e restrito a competicao da rota: sem isso, qualquer slug valido
+  // moderava doacao de qualquer competicao, e um slug de outra competicao
+  // selecionava o webhook errado.
+  const { count } = await dbClient.donations.updateMany({
     where: {
       id: donationId,
+      competitionId,
     },
     data: {
       status,
+    },
+  });
+
+  if (count === 0) return null;
+
+  return await dbClient.donations.findUnique({
+    where: {
+      id: donationId,
     },
   });
 }


### PR DESCRIPTION
Corrige o finding Major do CodeRabbit no #62. É código anterior aos meus PRs, mas eu toquei nesse arquivo no #61, então vai junto.

## O problema

O handler mutava a doação **antes** de resolver a competição do slug:

```ts
const updatedDonation = await updateDonationStatus({ donationId, status });  // ← muta

const competitionSlug = String(getRouterParam(event, 'slug'));
const competition = await getCompetitionBySlugForBackoffice(competitionSlug);
if (!competition) {
  throw createError({ statusCode: 404, ... });                              // ← só agora confere
}
```

Três consequências:

1. **Slug inexistente altera o dado e devolve 404.** A requisição "falha" tendo mudado o status da doação.
2. **Slug de outra competição escolhe o `webhook_configs` errado** — o webhook de aprovação vai para o destino da competição errada, com o `hemocioneId` de uma doação que não é dela.
3. **A doação nunca era vinculada à competição da rota.** Qualquer slug válido moderava doação de qualquer competição.

## O que muda

A competição é resolvida primeiro, e o update passa a ser restrito por `competitionId`:

```ts
const { count } = await dbClient.donations.updateMany({
  where: { id: donationId, competitionId },
  data: { status },
});
if (count === 0) return null;
```

Doação inexistente ou pertencente a outra competição responde **404 sem alterar nada**. Acrescentei também a validação de `donationId` como inteiro, que faltava — `Number("abc")` virava `NaN` e ia para o Prisma.

`updateDonationStatus` tem só um call site (este handler), conferido por grep.

## Verificação

```
$ npx -p vue-tsc@2.1.10 -p typescript@5.6.3 vue-tsc --noEmit | grep -c "error TS"
15                                    # baseline do repo, inalterado
```

Os dois erros que aparecem neste arquivo são os `donation_approved` de tipagem do campo `Json` do Prisma, pré-existentes — antes nas linhas 42-43, agora 61-62 porque o arquivo cresceu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)