### PR TITLE
feat: gamificação — avatar do doador (hemocionezinho) + achievements

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -76,6 +76,10 @@ export default defineNuxtConfig({
     donationsQueueUrl: process.env.DONATIONS_QUEUE_URL ?? "queue-url",
     ondeDoarApiUrl:
       process.env.ONDE_DOAR_API_URL ?? "https://ondedoar.hemocione.com.br",
+    hemocioneIdApiUrl:
+      process.env.HEMOCIONE_ID_API_URL ?? "http://localhost:8080",
+    hemocioneIdFactsSecret:
+      process.env.HEMOCIONE_ID_FACTS_SECRET ?? "secret",
   },
 
   routeRules: {

--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -3,6 +3,8 @@ import { updateDonationStatus } from "~/server/services/donationService";
 import { getCompetitionBySlug } from "~/server/services/competitionService";
 import { waitUntil } from '@vercel/functions';
 import { callWebhook } from "~/server/services/webhookService";
+import { runAsync } from "~/utils/runAsync";
+import { postFactToHemocioneId } from "~/server/services/hemocioneIdFacts";
 
 export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
@@ -41,6 +43,18 @@ export default defineEventHandler(async (event) => {
 
   if (updatedDonation.status === "approved" && competition.webhook_configs?.donation_approved) {
     waitUntil(callWebhook(competition.webhook_configs?.donation_approved, { hemocioneId: updatedDonation.hemocioneID }));
+  }
+
+  if (updatedDonation.status === "approved" && updatedDonation.hemocioneID) {
+    runAsync(
+      postFactToHemocioneId({
+        userId: updatedDonation.hemocioneID,
+        eventType: "competition.participated",
+        occurredAt: updatedDonation.updatedAt.toISOString(),
+        payload: { competitionId: updatedDonation.competitionId, kind: updatedDonation.kind },
+        idempotencyKey: `hemocione-competitions:competition.participated:donation-${updatedDonation.id}`,
+      })
+    );
   }
 
   return updatedDonation

--- a/server/api/v1/competitions/[slug]/donations/index.post.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.post.ts
@@ -6,6 +6,8 @@ import { callWebhook } from "~/server/services/webhookService";
 import { getPrettyFullName } from "~/utils/getPrettyFullName";
 import { isAllowedProofUrl } from "~/utils/proofUrl";
 import { resolveGeoValidation } from "~/utils/geo";
+import { runAsync } from "~/utils/runAsync";
+import { postFactToHemocioneId } from "~/server/services/hemocioneIdFacts";
 import {
   isValidExtraFieldsResponse,
   type ExtraFields,
@@ -163,6 +165,18 @@ export default defineEventHandler(async (event) => {
     competition.webhook_configs?.donation_approved
   ) {
     waitUntil(callWebhook(competition.webhook_configs.donation_approved, { hemocioneId: user.id }));
+  }
+
+  if (createdDonation.status === "approved" && createdDonation.hemocioneID) {
+    runAsync(
+      postFactToHemocioneId({
+        userId: createdDonation.hemocioneID,
+        eventType: "competition.participated",
+        occurredAt: createdDonation.createdAt.toISOString(),
+        payload: { competitionId: createdDonation.competitionId, kind: createdDonation.kind },
+        idempotencyKey: `hemocione-competitions:competition.participated:donation-${createdDonation.id}`,
+      })
+    );
   }
 
   return createdDonation;

--- a/server/api/v1/internal/reconciliation/facts.get.ts
+++ b/server/api/v1/internal/reconciliation/facts.get.ts
@@ -1,0 +1,11 @@
+import { assertHemocioneIdIntegrationSecret } from "~/server/services/auth";
+import { getReconciliationFactsSince } from "~/server/services/factsReconciliationService";
+
+export default defineEventHandler(async (event) => {
+  assertHemocioneIdIntegrationSecret(event);
+
+  const since = String(getQuery(event).since ?? new Date(0).toISOString());
+  const facts = await getReconciliationFactsSince(new Date(since));
+
+  return { facts };
+});

--- a/server/services/factsReconciliationService.ts
+++ b/server/services/factsReconciliationService.ts
@@ -1,0 +1,62 @@
+import { dbClient } from "~/server/db";
+import { getCompetitionRanking } from "./competitionService";
+import { pickWinningTeam } from "./pickWinningTeam";
+
+type Fact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// `updatedAt` is not a perfect proxy for "became approved just now" (any edit to the
+// row bumps it), but hemocione-id's fact ingestion is idempotent by idempotencyKey —
+// re-including a donation that was already approved before `since` is a harmless
+// no-op downstream, so this stays simple instead of tracking an approvedAt column.
+const getParticipatedFacts = async (since: Date): Promise<Fact[]> => {
+  const donations = await dbClient.donations.findMany({
+    where: { status: "approved", updatedAt: { gte: since }, hemocioneID: { not: null } },
+  });
+
+  return donations.map((donation) => ({
+    userId: donation.hemocioneID as string,
+    eventType: "competition.participated",
+    occurredAt: donation.updatedAt.toISOString(),
+    payload: { competitionId: donation.competitionId, kind: donation.kind },
+    idempotencyKey: `hemocione-competitions:competition.participated:donation-${donation.id}`,
+  }));
+};
+
+const getWonFacts = async (since: Date): Promise<Fact[]> => {
+  const finishedCompetitions = await dbClient.competitions.findMany({
+    where: { end_at: { gte: since, lt: new Date() } },
+  });
+
+  const facts: Fact[] = [];
+  for (const competition of finishedCompetitions) {
+    const ranking = await getCompetitionRanking(competition.id);
+    const winner = pickWinningTeam(ranking);
+    if (!winner) continue;
+
+    const members = await dbClient.donations.findMany({
+      where: { competitionTeamId: winner.teamId, competitionId: competition.id, hemocioneID: { not: null } },
+    });
+
+    for (const member of members) {
+      facts.push({
+        userId: member.hemocioneID as string,
+        eventType: "competition.won",
+        occurredAt: competition.end_at.toISOString(),
+        payload: { competitionId: competition.id, teamId: winner.teamId },
+        idempotencyKey: `hemocione-competitions:competition.won:${competition.id}:${member.hemocioneID}`,
+      });
+    }
+  }
+  return facts;
+};
+
+export const getReconciliationFactsSince = async (since: Date): Promise<Fact[]> => {
+  const [participated, won] = await Promise.all([getParticipatedFacts(since), getWonFacts(since)]);
+  return [...participated, ...won];
+};

--- a/server/services/hemocioneIdFacts.ts
+++ b/server/services/hemocioneIdFacts.ts
@@ -1,0 +1,25 @@
+const config = useRuntimeConfig();
+
+type GamificationFact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// Deliberately catches internally — this is a fire-and-forget side effect called via
+// runAsync/waitUntil, and a rejected promise there would surface as an unhandled
+// rejection instead of failing the caller (there is no caller awaiting it to fail).
+export async function postFactToHemocioneId(fact: GamificationFact) {
+  try {
+    await $fetch(`${config.hemocioneIdApiUrl}/internal/facts`, {
+      method: "POST",
+      body: { ...fact, sourceService: "hemocione-competitions" },
+      headers: { "x-secret": config.hemocioneIdFactsSecret },
+      timeout: 5000,
+    });
+  } catch (error) {
+    console.error("[gamification] failed to push fact to hemocione-id", error);
+  }
+}

--- a/server/services/pickWinningTeam.test.ts
+++ b/server/services/pickWinningTeam.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { pickWinningTeam } from "./pickWinningTeam";
+
+describe("pickWinningTeam", () => {
+  it("returns the team with the highest donation_count", () => {
+    const ranking = [
+      { teamId: 1, donation_count: 3 },
+      { teamId: 2, donation_count: 10 },
+      { teamId: 3, donation_count: 7 },
+    ];
+    expect(pickWinningTeam(ranking)?.teamId).toBe(2);
+  });
+
+  it("returns null when there is no ranking data", () => {
+    expect(pickWinningTeam([])).toBeNull();
+  });
+
+  it("returns null when every team has zero or null donation_count", () => {
+    const ranking = [
+      { teamId: 1, donation_count: 0 },
+      { teamId: 2, donation_count: null },
+    ];
+    expect(pickWinningTeam(ranking)).toBeNull();
+  });
+});

--- a/server/services/pickWinningTeam.ts
+++ b/server/services/pickWinningTeam.ts
@@ -1,0 +1,12 @@
+export const pickWinningTeam = (
+  ranking: Array<{ teamId: number; donation_count: number | null }>
+): { teamId: number; donation_count: number | null } | null => {
+  if (ranking.length === 0) return null;
+
+  const sorted = [...ranking].sort(
+    (a, b) => (b.donation_count ?? 0) - (a.donation_count ?? 0)
+  );
+  if ((sorted[0].donation_count ?? 0) === 0) return null;
+
+  return sorted[0];
+};


### PR DESCRIPTION
Motor de conquistas/achievements movido a fatos (`user_facts`) e avatar customizável ("hemocionezinho") desbloqueado por conquistas. Parte de uma feature cross-repo (hemocione-id + hemocione-app + hemocione-competitions + hemocione-digital-event). Deploy em DEV já validado manualmente nesta sessão; este PR sincroniza `develop` para ficar visível em `app.d.hemocione.com.br`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hemocione ID integration for reporting approved donations, participation, and winning-team achievements.
  * Added secure reconciliation access for retrieving generated integration facts.
  * Added automatic identification of winning teams based on donation rankings.

* **Bug Fixes**
  * Improved handling of empty rankings and teams without donations.

* **Tests**
  * Added coverage for winning-team selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->