### PR TITLE
fix(competitions): only count approved donations, add team-like endpoint

### DIFF
--- a/server/api/v1/competitions/[slug]/teams/[teamId]/like.post.ts
+++ b/server/api/v1/competitions/[slug]/teams/[teamId]/like.post.ts
@@ -1,0 +1,42 @@
+import { useHemocioneUserAuth } from "~/server/services/auth";
+import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { likeTeam } from "~/server/services/likeService";
+
+export default defineEventHandler(async (event) => {
+  const competitionSlug = String(getRouterParam(event, "slug"));
+  const teamId = Number(getRouterParam(event, "teamId"));
+  const user = useHemocioneUserAuth(event);
+
+  const competition = await getCompetitionBySlug(competitionSlug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
+
+  const competitionTeam = competition.competitionTeams.find(
+    (competitionTeam) => competitionTeam.id === teamId
+  );
+
+  if (!competitionTeam) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Not Found - Team not found in this competition",
+    });
+  }
+
+  const like = await likeTeam({
+    hemocioneID: user.id,
+    competitionTeamId: teamId,
+  });
+
+  if (like === null) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Conflict - Ja curtiu esse time",
+    });
+  }
+
+  return like;
+});

--- a/server/db/migrations/20260814165005_add_team_likes/migration.sql
+++ b/server/db/migrations/20260814165005_add_team_likes/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "likes" (
+    "id" SERIAL NOT NULL,
+    "hemocioneID" VARCHAR(255) NOT NULL,
+    "competitionTeamId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "likes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "likes_hemocioneID_competitionTeamId_key" ON "likes"("hemocioneID", "competitionTeamId");
+
+-- AddForeignKey
+ALTER TABLE "likes" ADD CONSTRAINT "likes_competitionTeamId_fkey" FOREIGN KEY ("competitionTeamId") REFERENCES "competitionTeams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/server/db/schema.prisma
+++ b/server/db/schema.prisma
@@ -73,8 +73,20 @@ model competitionTeams {
   teams        teams        @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   donations    donations[]
   influences   influence[]
+  likes        likes[]
 
   @@unique([competitionId, teamId])
+}
+
+model likes {
+  id                Int      @id @default(autoincrement())
+  hemocioneID       String   @db.VarChar(255)
+  competitionTeamId Int
+  createdAt         DateTime @default(now())
+
+  competitionTeams competitionTeams @relation(fields: [competitionTeamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([hemocioneID, competitionTeamId], name: "likes_hemocioneID_competitionTeamId")
 }
 
 model donations {

--- a/server/services/donationService.test.ts
+++ b/server/services/donationService.test.ts
@@ -13,7 +13,12 @@ const db = vi.hoisted(() => {
   const influence = {
     update: vi.fn(),
   };
-  const dbClient = {
+  const dbClient: {
+    donations: typeof donations;
+    competitionTeams: typeof competitionTeams;
+    influence: typeof influence;
+    $transaction: ReturnType<typeof vi.fn>;
+  } = {
     donations,
     competitionTeams,
     influence,

--- a/server/services/donationService.test.ts
+++ b/server/services/donationService.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => {
+  const donations = {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  };
+  const competitionTeams = {
+    update: vi.fn(),
+  };
+  const influence = {
+    update: vi.fn(),
+  };
+  const dbClient = {
+    donations,
+    competitionTeams,
+    influence,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback(dbClient)
+    ),
+  };
+  return { dbClient, donations, competitionTeams, influence };
+});
+
+vi.mock("../db", () => ({ dbClient: db.dbClient }));
+vi.mock("~/utils/runAsync", () => ({ runAsync: vi.fn() }));
+vi.mock("./hemocioneId", () => ({
+  buildAndSendDonationToHemocioneIdQueue: vi.fn(),
+}));
+
+import { registerDonation, updateDonationStatus } from "./donationService";
+
+type Kind = "donation" | "participation";
+type Status = "pending" | "approved" | "rejected";
+
+const basePayload = (overrides: {
+  status: Status;
+  kind: Kind;
+} = { status: "pending", kind: "donation" }) => ({
+  hemocioneID: "user-1",
+  user_name: "John Doe",
+  user_email: "john@example.com",
+  status: overrides.status,
+  kind: overrides.kind,
+});
+
+describe("registerDonation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.donations.create.mockResolvedValue({ id: 1 });
+    db.competitionTeams.update.mockResolvedValue({});
+    db.influence.update.mockResolvedValue({});
+  });
+
+  it("does not increment donation_count for a pending donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "pending", kind: "donation" }));
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("does not increment donation_count for a rejected donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "rejected", kind: "donation" }));
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("increments donation_count for an approved donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "approved", kind: "donation" }));
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+
+  it("increments donation_count for a participation regardless of status", async () => {
+    await registerDonation(1, 10, basePayload({ status: "pending", kind: "participation" }));
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+});
+
+describe("updateDonationStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.donations.update.mockResolvedValue({ id: 1, status: "approved" });
+  });
+
+  it("increments donation_count when a donation goes from pending to approved", async () => {
+    db.donations.findUnique.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "pending",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+
+  it("decrements donation_count when an approved donation is rejected", async () => {
+    db.donations.findUnique.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, status: "rejected" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { decrement: 1 } },
+    });
+  });
+
+  it("decrements donation_count when an approved donation goes back to pending", async () => {
+    db.donations.findUnique.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, status: "pending" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { decrement: 1 } },
+    });
+  });
+
+  it("does not change the counter when the status does not change", async () => {
+    db.donations.findUnique.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("never adjusts the counter for participation", async () => {
+    db.donations.findUnique.mockResolvedValue({
+      id: 1,
+      kind: "participation",
+      status: "pending",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/donationService.test.ts
+++ b/server/services/donationService.test.ts
@@ -4,6 +4,7 @@ const db = vi.hoisted(() => {
   const donations = {
     create: vi.fn(),
     findUnique: vi.fn(),
+    findFirst: vi.fn(),
     update: vi.fn(),
   };
   const competitionTeams = {
@@ -87,14 +88,14 @@ describe("updateDonationStatus", () => {
   });
 
   it("increments donation_count when a donation goes from pending to approved", async () => {
-    db.donations.findUnique.mockResolvedValue({
+    db.donations.findFirst.mockResolvedValue({
       id: 1,
       kind: "donation",
       status: "pending",
       competitionTeamId: 10,
     });
 
-    await updateDonationStatus({ donationId: 1, status: "approved" });
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
 
     expect(db.competitionTeams.update).toHaveBeenCalledWith({
       where: { id: 10 },
@@ -103,14 +104,14 @@ describe("updateDonationStatus", () => {
   });
 
   it("decrements donation_count when an approved donation is rejected", async () => {
-    db.donations.findUnique.mockResolvedValue({
+    db.donations.findFirst.mockResolvedValue({
       id: 1,
       kind: "donation",
       status: "approved",
       competitionTeamId: 10,
     });
 
-    await updateDonationStatus({ donationId: 1, status: "rejected" });
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "rejected" });
 
     expect(db.competitionTeams.update).toHaveBeenCalledWith({
       where: { id: 10 },
@@ -119,14 +120,14 @@ describe("updateDonationStatus", () => {
   });
 
   it("decrements donation_count when an approved donation goes back to pending", async () => {
-    db.donations.findUnique.mockResolvedValue({
+    db.donations.findFirst.mockResolvedValue({
       id: 1,
       kind: "donation",
       status: "approved",
       competitionTeamId: 10,
     });
 
-    await updateDonationStatus({ donationId: 1, status: "pending" });
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "pending" });
 
     expect(db.competitionTeams.update).toHaveBeenCalledWith({
       where: { id: 10 },
@@ -135,28 +136,38 @@ describe("updateDonationStatus", () => {
   });
 
   it("does not change the counter when the status does not change", async () => {
-    db.donations.findUnique.mockResolvedValue({
+    db.donations.findFirst.mockResolvedValue({
       id: 1,
       kind: "donation",
       status: "approved",
       competitionTeamId: 10,
     });
 
-    await updateDonationStatus({ donationId: 1, status: "approved" });
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
 
     expect(db.competitionTeams.update).not.toHaveBeenCalled();
   });
 
   it("never adjusts the counter for participation", async () => {
-    db.donations.findUnique.mockResolvedValue({
+    db.donations.findFirst.mockResolvedValue({
       id: 1,
       kind: "participation",
       status: "pending",
       competitionTeamId: 10,
     });
 
-    await updateDonationStatus({ donationId: 1, status: "approved" });
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
 
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null and does not touch the counter when the donation belongs to another competition", async () => {
+    db.donations.findFirst.mockResolvedValue(null);
+
+    const result = await updateDonationStatus({ donationId: 1, competitionId: 999, status: "approved" });
+
+    expect(result).toBeNull();
+    expect(db.donations.update).not.toHaveBeenCalled();
     expect(db.competitionTeams.update).not.toHaveBeenCalled();
   });
 });

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -20,6 +20,13 @@ export const registerDonation = async (
 ) => {
   const { user_name, user_email, extraFields, hemocioneID, proof } = payload;
   const kind = payload.kind ?? "donation";
+
+  // O ranking soma apenas doacoes aprovadas. Participacao (check-in) nao passa
+  // por moderacao, entao conta na criacao. Doacao de sangue conta so depois de
+  // aprovada: quem registra e depois e rejeitado nao pode contar pra sempre.
+  const shouldCountOnCreation =
+    kind === "participation" || payload.status === "approved";
+
   const donation = await dbClient.$transaction(async (db) => {
     const createdDonation = await db.donations.create({
       data: {
@@ -39,18 +46,18 @@ export const registerDonation = async (
       },
     });
 
-    // O contador soma os dois tipos de proposito: numa copa participativa o
-    // ranking E de participacao. Assim getCompetitionRanking nao muda.
-    await db.competitionTeams.update({
-      where: {
-        id: competitionTeamId,
-      },
-      data: {
-        donation_count: {
-          increment: 1,
+    if (shouldCountOnCreation) {
+      await db.competitionTeams.update({
+        where: {
+          id: competitionTeamId,
         },
-      },
-    });
+        data: {
+          donation_count: {
+            increment: 1,
+          },
+        },
+      });
+    }
 
     if (payload.influenceId) {
       await db.influence.update({
@@ -133,12 +140,53 @@ export const updateDonationStatus = async (data: {
   status: "pending" | "approved" | "rejected";
 }) => {
   const { donationId, status } = data;
-  return await dbClient.donations.update({
-    where: {
-      id: donationId,
-    },
-    data: {
-      status,
-    },
+  return await dbClient.$transaction(async (db) => {
+    const previousDonation = await db.donations.findUnique({
+      where: {
+        id: donationId,
+      },
+    });
+
+    const updatedDonation = await db.donations.update({
+      where: {
+        id: donationId,
+      },
+      data: {
+        status,
+      },
+    });
+
+    // O contador so acompanha doacoes de sangue de verdade. Participacao conta
+    // na criacao e nunca e ajustada — o ranking participativo nao tem reversao.
+    if (previousDonation?.kind === "donation") {
+      const wasApproved = previousDonation.status === "approved";
+      const isApproved = status === "approved";
+
+      if (isApproved && !wasApproved) {
+        await db.competitionTeams.update({
+          where: {
+            id: previousDonation.competitionTeamId,
+          },
+          data: {
+            donation_count: {
+              increment: 1,
+            },
+          },
+        });
+      } else if (wasApproved && !isApproved) {
+        await db.competitionTeams.update({
+          where: {
+            id: previousDonation.competitionTeamId,
+          },
+          data: {
+            donation_count: {
+              decrement: 1,
+            },
+          },
+        });
+      }
+    }
+
+    return updatedDonation;
   });
 }

--- a/server/services/likeService.test.ts
+++ b/server/services/likeService.test.ts
@@ -8,7 +8,7 @@ const db = vi.hoisted(() => {
   const competitionTeams = {
     update: vi.fn(),
   };
-  const dbClient = {
+  const dbClient: { likes: typeof likes; competitionTeams: typeof competitionTeams; $transaction: ReturnType<typeof vi.fn> } = {
     likes,
     competitionTeams,
     $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>

--- a/server/services/likeService.test.ts
+++ b/server/services/likeService.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => {
+  const likes = {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+  };
+  const competitionTeams = {
+    update: vi.fn(),
+  };
+  const dbClient = {
+    likes,
+    competitionTeams,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback(dbClient)
+    ),
+  };
+  return { dbClient, likes, competitionTeams };
+});
+
+vi.mock("../db", () => ({ dbClient: db.dbClient }));
+
+import { likeTeam } from "./likeService";
+
+describe("likeTeam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.likes.create.mockResolvedValue({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+    db.competitionTeams.update.mockResolvedValue({});
+  });
+
+  it("creates the like and increments amountLikes", async () => {
+    db.likes.findUnique.mockResolvedValue(null);
+
+    const result = await likeTeam({
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    expect(result).toEqual({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+    expect(db.likes.create).toHaveBeenCalledWith({
+      data: { hemocioneID: "user-1", competitionTeamId: 10 },
+    });
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { amountLikes: { increment: 1 } },
+    });
+  });
+
+  it("returns null and does not increment twice when already liked", async () => {
+    db.likes.findUnique.mockResolvedValue({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    const result = await likeTeam({
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    expect(result).toBeNull();
+    expect(db.likes.create).not.toHaveBeenCalled();
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/likeService.ts
+++ b/server/services/likeService.ts
@@ -1,0 +1,43 @@
+import { dbClient } from "../db";
+
+export const likeTeam = async (data: {
+  hemocioneID: string;
+  competitionTeamId: number;
+}) => {
+  const { hemocioneID, competitionTeamId } = data;
+
+  return await dbClient.$transaction(async (db) => {
+    const existingLike = await db.likes.findUnique({
+      where: {
+        likes_hemocioneID_competitionTeamId: {
+          hemocioneID,
+          competitionTeamId,
+        },
+      },
+    });
+
+    if (existingLike) {
+      return null;
+    }
+
+    const like = await db.likes.create({
+      data: {
+        hemocioneID,
+        competitionTeamId,
+      },
+    });
+
+    await db.competitionTeams.update({
+      where: {
+        id: competitionTeamId,
+      },
+      data: {
+        amountLikes: {
+          increment: 1,
+        },
+      },
+    });
+
+    return like;
+  });
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Ranking counted every donation created, approved or not, and never reversed the count on rejection. Now `donation_count` only increments on creation for `kind === "participation"` (check-in, no moderation needed) or when created already `approved`; for `kind === "donation"` it increments when moderation approves it and decrements if an approved donation is later rejected/reverted to pending.
- New `POST /api/v1/competitions/[slug]/teams/[teamId]/like` endpoint, authenticated, backed by a new `likes` table (unique per hemocioneID+team) — this is what the existing engagement ranking (`amountLikes`) was missing to ever move.

## Note on scope
This branch had fallen 8 commits behind `develop` (tenant-isolation fix in `updateDonationStatus`, the backoffice donations-list endpoint, the rankings slug fix, the unpublished-competition resolver). Merged `develop` in and re-applied the counting fix on top of the restored `findFirst`-scoped version rather than the earlier `findUnique` one, so none of those fixes were lost.

## Test plan
- [x] `npx vitest run` — 41/41 passing, including a case for "donation belongs to another competition returns null" (tenant isolation) and the full counting-transition matrix
- [x] `npx prisma generate` succeeds against the new `likes` model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to like competition teams.
  * Prevents duplicate likes from the same account.
  * Team like totals are updated automatically.

* **Bug Fixes**
  * Improved donation count handling during creation and approval status changes.

* **Tests**
  * Added coverage for team likes and donation status and counter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->