### PR TITLE
fix(auth): navigateTo externo sem flag causa 500 no login da copa

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -86,5 +86,5 @@ export function getRedirectToIdUrl(fullPath: string) {
 }
 
 export function redirectToID(fullPath: string) {
-  return navigateTo(getRedirectToIdUrl(fullPath));
+  return navigateTo(getRedirectToIdUrl(fullPath), { external: true });
 }


### PR DESCRIPTION
## Problema

Alunos do fluxo YDUQS (evento Presidente Vargas, ao vivo hoje) relataram erro 500
ao tentar enviar o comprovante de participação/doação em
`/competition/:slug/register`.

## Causa raiz

`middleware/auth.ts` chama `navigateTo(getRedirectToIdUrl(fullPath))` sem
`{ external: true }`. `getRedirectToIdUrl` monta uma URL absoluta para
`hemocioneIdUrl` (`id.hemocione.com.br` em prod), domínio diferente de
`siteUrl` (`copa.hemocione.com.br`). O Nuxt lança 500 por padrão quando
`navigateTo` recebe uma URL de outra origem sem o flag `external`.

Qualquer pessoa sem sessão válida na copa que abre a tela de registro/comprovante
cai nesse redirect e trava — o que cobre praticamente todo mundo chegando pela
primeira vez num evento.

O padrão correto já existe no mesmo repo (`register.vue`, `success.vue`), só essa
chamada ficou sem o flag.

## Fix

Uma linha: adiciona `{ external: true }` na chamada de `navigateTo`.

## Test plan

- [ ] Abrir `/competition/:slug/register` sem cookie/token válido e confirmar
      redirecionamento para o login do hemocione-id (sem 500).
- [ ] Fluxo completo: login -> voltar pra `/register` -> anexar comprovante ->
      registrar participação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)