### PR TITLE
release: promover develop para produção

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -76,6 +76,10 @@ export default defineNuxtConfig({
     donationsQueueUrl: process.env.DONATIONS_QUEUE_URL ?? "queue-url",
     ondeDoarApiUrl:
       process.env.ONDE_DOAR_API_URL ?? "https://ondedoar.hemocione.com.br",
+    hemocioneIdApiUrl:
+      process.env.HEMOCIONE_ID_API_URL ?? "http://localhost:8080",
+    hemocioneIdFactsSecret:
+      process.env.HEMOCIONE_ID_FACTS_SECRET ?? "secret",
   },
 
   routeRules: {

--- a/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
+++ b/server/api/v1/competitions/[slug]/donations/[donationId]/status/index.put.ts
@@ -3,6 +3,8 @@ import { updateDonationStatus } from "~/server/services/donationService";
 import { getCompetitionBySlug } from "~/server/services/competitionService";
 import { waitUntil } from '@vercel/functions';
 import { callWebhook } from "~/server/services/webhookService";
+import { runAsync } from "~/utils/runAsync";
+import { postFactToHemocioneId } from "~/server/services/hemocioneIdFacts";
 
 export default defineEventHandler(async (event) => {
   assertSecretAuth(event);
@@ -41,6 +43,18 @@ export default defineEventHandler(async (event) => {
 
   if (updatedDonation.status === "approved" && competition.webhook_configs?.donation_approved) {
     waitUntil(callWebhook(competition.webhook_configs?.donation_approved, { hemocioneId: updatedDonation.hemocioneID }));
+  }
+
+  if (updatedDonation.status === "approved" && updatedDonation.hemocioneID) {
+    runAsync(
+      postFactToHemocioneId({
+        userId: updatedDonation.hemocioneID,
+        eventType: "competition.participated",
+        occurredAt: updatedDonation.updatedAt.toISOString(),
+        payload: { competitionId: updatedDonation.competitionId, kind: updatedDonation.kind },
+        idempotencyKey: `hemocione-competitions:competition.participated:donation-${updatedDonation.id}`,
+      })
+    );
   }
 
   return updatedDonation

--- a/server/api/v1/competitions/[slug]/donations/index.post.ts
+++ b/server/api/v1/competitions/[slug]/donations/index.post.ts
@@ -6,6 +6,8 @@ import { callWebhook } from "~/server/services/webhookService";
 import { getPrettyFullName } from "~/utils/getPrettyFullName";
 import { isAllowedProofUrl } from "~/utils/proofUrl";
 import { resolveGeoValidation } from "~/utils/geo";
+import { runAsync } from "~/utils/runAsync";
+import { postFactToHemocioneId } from "~/server/services/hemocioneIdFacts";
 import {
   isValidExtraFieldsResponse,
   type ExtraFields,
@@ -163,6 +165,18 @@ export default defineEventHandler(async (event) => {
     competition.webhook_configs?.donation_approved
   ) {
     waitUntil(callWebhook(competition.webhook_configs.donation_approved, { hemocioneId: user.id }));
+  }
+
+  if (createdDonation.status === "approved" && createdDonation.hemocioneID) {
+    runAsync(
+      postFactToHemocioneId({
+        userId: createdDonation.hemocioneID,
+        eventType: "competition.participated",
+        occurredAt: createdDonation.createdAt.toISOString(),
+        payload: { competitionId: createdDonation.competitionId, kind: createdDonation.kind },
+        idempotencyKey: `hemocione-competitions:competition.participated:donation-${createdDonation.id}`,
+      })
+    );
   }
 
   return createdDonation;

--- a/server/api/v1/competitions/[slug]/teams/[teamId]/like.post.ts
+++ b/server/api/v1/competitions/[slug]/teams/[teamId]/like.post.ts
@@ -1,0 +1,42 @@
+import { useHemocioneUserAuth } from "~/server/services/auth";
+import { getCompetitionBySlug } from "~/server/services/competitionService";
+import { likeTeam } from "~/server/services/likeService";
+
+export default defineEventHandler(async (event) => {
+  const competitionSlug = String(getRouterParam(event, "slug"));
+  const teamId = Number(getRouterParam(event, "teamId"));
+  const user = useHemocioneUserAuth(event);
+
+  const competition = await getCompetitionBySlug(competitionSlug);
+  if (!competition) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Competition not found",
+    });
+  }
+
+  const competitionTeam = competition.competitionTeams.find(
+    (competitionTeam) => competitionTeam.id === teamId
+  );
+
+  if (!competitionTeam) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Not Found - Team not found in this competition",
+    });
+  }
+
+  const like = await likeTeam({
+    hemocioneID: user.id,
+    competitionTeamId: teamId,
+  });
+
+  if (like === null) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Conflict - Ja curtiu esse time",
+    });
+  }
+
+  return like;
+});

--- a/server/api/v1/internal/reconciliation/facts.get.ts
+++ b/server/api/v1/internal/reconciliation/facts.get.ts
@@ -1,0 +1,11 @@
+import { assertHemocioneIdIntegrationSecret } from "~/server/services/auth";
+import { getReconciliationFactsSince } from "~/server/services/factsReconciliationService";
+
+export default defineEventHandler(async (event) => {
+  assertHemocioneIdIntegrationSecret(event);
+
+  const since = String(getQuery(event).since ?? new Date(0).toISOString());
+  const facts = await getReconciliationFactsSince(new Date(since));
+
+  return { facts };
+});

--- a/server/db/migrations/20260814165005_add_team_likes/migration.sql
+++ b/server/db/migrations/20260814165005_add_team_likes/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "likes" (
+    "id" SERIAL NOT NULL,
+    "hemocioneID" VARCHAR(255) NOT NULL,
+    "competitionTeamId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "likes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "likes_hemocioneID_competitionTeamId_key" ON "likes"("hemocioneID", "competitionTeamId");
+
+-- AddForeignKey
+ALTER TABLE "likes" ADD CONSTRAINT "likes_competitionTeamId_fkey" FOREIGN KEY ("competitionTeamId") REFERENCES "competitionTeams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/server/db/schema.prisma
+++ b/server/db/schema.prisma
@@ -73,8 +73,20 @@ model competitionTeams {
   teams        teams        @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   donations    donations[]
   influences   influence[]
+  likes        likes[]
 
   @@unique([competitionId, teamId])
+}
+
+model likes {
+  id                Int      @id @default(autoincrement())
+  hemocioneID       String   @db.VarChar(255)
+  competitionTeamId Int
+  createdAt         DateTime @default(now())
+
+  competitionTeams competitionTeams @relation(fields: [competitionTeamId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([hemocioneID, competitionTeamId], name: "likes_hemocioneID_competitionTeamId")
 }
 
 model donations {

--- a/server/services/donationService.test.ts
+++ b/server/services/donationService.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => {
+  const donations = {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  };
+  const competitionTeams = {
+    update: vi.fn(),
+  };
+  const influence = {
+    update: vi.fn(),
+  };
+  const dbClient: {
+    donations: typeof donations;
+    competitionTeams: typeof competitionTeams;
+    influence: typeof influence;
+    $transaction: ReturnType<typeof vi.fn>;
+  } = {
+    donations,
+    competitionTeams,
+    influence,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback(dbClient)
+    ),
+  };
+  return { dbClient, donations, competitionTeams, influence };
+});
+
+vi.mock("../db", () => ({ dbClient: db.dbClient }));
+vi.mock("~/utils/runAsync", () => ({ runAsync: vi.fn() }));
+vi.mock("./hemocioneId", () => ({
+  buildAndSendDonationToHemocioneIdQueue: vi.fn(),
+}));
+
+import { registerDonation, updateDonationStatus } from "./donationService";
+
+type Kind = "donation" | "participation";
+type Status = "pending" | "approved" | "rejected";
+
+const basePayload = (overrides: {
+  status: Status;
+  kind: Kind;
+} = { status: "pending", kind: "donation" }) => ({
+  hemocioneID: "user-1",
+  user_name: "John Doe",
+  user_email: "john@example.com",
+  status: overrides.status,
+  kind: overrides.kind,
+});
+
+describe("registerDonation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.donations.create.mockResolvedValue({ id: 1 });
+    db.competitionTeams.update.mockResolvedValue({});
+    db.influence.update.mockResolvedValue({});
+  });
+
+  it("does not increment donation_count for a pending donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "pending", kind: "donation" }));
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("does not increment donation_count for a rejected donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "rejected", kind: "donation" }));
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("increments donation_count for an approved donation", async () => {
+    await registerDonation(1, 10, basePayload({ status: "approved", kind: "donation" }));
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+
+  it("increments donation_count for a participation regardless of status", async () => {
+    await registerDonation(1, 10, basePayload({ status: "pending", kind: "participation" }));
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+});
+
+describe("updateDonationStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.donations.update.mockResolvedValue({ id: 1, status: "approved" });
+  });
+
+  it("increments donation_count when a donation goes from pending to approved", async () => {
+    db.donations.findFirst.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "pending",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { increment: 1 } },
+    });
+  });
+
+  it("decrements donation_count when an approved donation is rejected", async () => {
+    db.donations.findFirst.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "rejected" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { decrement: 1 } },
+    });
+  });
+
+  it("decrements donation_count when an approved donation goes back to pending", async () => {
+    db.donations.findFirst.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "pending" });
+
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { donation_count: { decrement: 1 } },
+    });
+  });
+
+  it("does not change the counter when the status does not change", async () => {
+    db.donations.findFirst.mockResolvedValue({
+      id: 1,
+      kind: "donation",
+      status: "approved",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("never adjusts the counter for participation", async () => {
+    db.donations.findFirst.mockResolvedValue({
+      id: 1,
+      kind: "participation",
+      status: "pending",
+      competitionTeamId: 10,
+    });
+
+    await updateDonationStatus({ donationId: 1, competitionId: 1, status: "approved" });
+
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null and does not touch the counter when the donation belongs to another competition", async () => {
+    db.donations.findFirst.mockResolvedValue(null);
+
+    const result = await updateDonationStatus({ donationId: 1, competitionId: 999, status: "approved" });
+
+    expect(result).toBeNull();
+    expect(db.donations.update).not.toHaveBeenCalled();
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/donationService.ts
+++ b/server/services/donationService.ts
@@ -20,6 +20,13 @@ export const registerDonation = async (
 ) => {
   const { user_name, user_email, extraFields, hemocioneID, proof } = payload;
   const kind = payload.kind ?? "donation";
+
+  // O ranking soma apenas doacoes aprovadas. Participacao (check-in) nao passa
+  // por moderacao, entao conta na criacao. Doacao de sangue conta so depois de
+  // aprovada: quem registra e depois e rejeitado nao pode contar pra sempre.
+  const shouldCountOnCreation =
+    kind === "participation" || payload.status === "approved";
+
   const donation = await dbClient.$transaction(async (db) => {
     const createdDonation = await db.donations.create({
       data: {
@@ -39,18 +46,18 @@ export const registerDonation = async (
       },
     });
 
-    // O contador soma os dois tipos de proposito: numa copa participativa o
-    // ranking E de participacao. Assim getCompetitionRanking nao muda.
-    await db.competitionTeams.update({
-      where: {
-        id: competitionTeamId,
-      },
-      data: {
-        donation_count: {
-          increment: 1,
+    if (shouldCountOnCreation) {
+      await db.competitionTeams.update({
+        where: {
+          id: competitionTeamId,
         },
-      },
-    });
+        data: {
+          donation_count: {
+            increment: 1,
+          },
+        },
+      });
+    }
 
     if (payload.influenceId) {
       await db.influence.update({
@@ -135,25 +142,60 @@ export const updateDonationStatus = async (data: {
 }) => {
   const { donationId, competitionId, status } = data;
 
-  // O update e restrito a competicao da rota: sem isso, qualquer slug valido
-  // moderava doacao de qualquer competicao, e um slug de outra competicao
-  // selecionava o webhook errado.
-  const { count } = await dbClient.donations.updateMany({
-    where: {
-      id: donationId,
-      competitionId,
-    },
-    data: {
-      status,
-    },
-  });
+  return await dbClient.$transaction(async (db) => {
+    // O update e restrito a competicao da rota: sem isso, qualquer slug valido
+    // moderava doacao de qualquer competicao, e um slug de outra competicao
+    // selecionava o webhook errado.
+    const previousDonation = await db.donations.findFirst({
+      where: {
+        id: donationId,
+        competitionId,
+      },
+    });
 
-  if (count === 0) return null;
+    if (!previousDonation) return null;
 
-  return await dbClient.donations.findUnique({
-    where: {
-      id: donationId,
-    },
+    const updatedDonation = await db.donations.update({
+      where: {
+        id: donationId,
+      },
+      data: {
+        status,
+      },
+    });
+
+    // O contador so acompanha doacoes de sangue de verdade. Participacao conta
+    // na criacao e nunca e ajustada — o ranking participativo nao tem reversao.
+    if (previousDonation.kind === "donation") {
+      const wasApproved = previousDonation.status === "approved";
+      const isApproved = status === "approved";
+
+      if (isApproved && !wasApproved) {
+        await db.competitionTeams.update({
+          where: {
+            id: previousDonation.competitionTeamId,
+          },
+          data: {
+            donation_count: {
+              increment: 1,
+            },
+          },
+        });
+      } else if (wasApproved && !isApproved) {
+        await db.competitionTeams.update({
+          where: {
+            id: previousDonation.competitionTeamId,
+          },
+          data: {
+            donation_count: {
+              decrement: 1,
+            },
+          },
+        });
+      }
+    }
+
+    return updatedDonation;
   });
 }
 

--- a/server/services/factsReconciliationService.ts
+++ b/server/services/factsReconciliationService.ts
@@ -1,0 +1,62 @@
+import { dbClient } from "~/server/db";
+import { getCompetitionRanking } from "./competitionService";
+import { pickWinningTeam } from "./pickWinningTeam";
+
+type Fact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// `updatedAt` is not a perfect proxy for "became approved just now" (any edit to the
+// row bumps it), but hemocione-id's fact ingestion is idempotent by idempotencyKey —
+// re-including a donation that was already approved before `since` is a harmless
+// no-op downstream, so this stays simple instead of tracking an approvedAt column.
+const getParticipatedFacts = async (since: Date): Promise<Fact[]> => {
+  const donations = await dbClient.donations.findMany({
+    where: { status: "approved", updatedAt: { gte: since }, hemocioneID: { not: null } },
+  });
+
+  return donations.map((donation) => ({
+    userId: donation.hemocioneID as string,
+    eventType: "competition.participated",
+    occurredAt: donation.updatedAt.toISOString(),
+    payload: { competitionId: donation.competitionId, kind: donation.kind },
+    idempotencyKey: `hemocione-competitions:competition.participated:donation-${donation.id}`,
+  }));
+};
+
+const getWonFacts = async (since: Date): Promise<Fact[]> => {
+  const finishedCompetitions = await dbClient.competitions.findMany({
+    where: { end_at: { gte: since, lt: new Date() } },
+  });
+
+  const facts: Fact[] = [];
+  for (const competition of finishedCompetitions) {
+    const ranking = await getCompetitionRanking(competition.id);
+    const winner = pickWinningTeam(ranking);
+    if (!winner) continue;
+
+    const members = await dbClient.donations.findMany({
+      where: { competitionTeamId: winner.teamId, competitionId: competition.id, hemocioneID: { not: null } },
+    });
+
+    for (const member of members) {
+      facts.push({
+        userId: member.hemocioneID as string,
+        eventType: "competition.won",
+        occurredAt: competition.end_at.toISOString(),
+        payload: { competitionId: competition.id, teamId: winner.teamId },
+        idempotencyKey: `hemocione-competitions:competition.won:${competition.id}:${member.hemocioneID}`,
+      });
+    }
+  }
+  return facts;
+};
+
+export const getReconciliationFactsSince = async (since: Date): Promise<Fact[]> => {
+  const [participated, won] = await Promise.all([getParticipatedFacts(since), getWonFacts(since)]);
+  return [...participated, ...won];
+};

--- a/server/services/hemocioneIdFacts.ts
+++ b/server/services/hemocioneIdFacts.ts
@@ -1,0 +1,25 @@
+const config = useRuntimeConfig();
+
+type GamificationFact = {
+  userId: string;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// Deliberately catches internally — this is a fire-and-forget side effect called via
+// runAsync/waitUntil, and a rejected promise there would surface as an unhandled
+// rejection instead of failing the caller (there is no caller awaiting it to fail).
+export async function postFactToHemocioneId(fact: GamificationFact) {
+  try {
+    await $fetch(`${config.hemocioneIdApiUrl}/internal/facts`, {
+      method: "POST",
+      body: { ...fact, sourceService: "hemocione-competitions" },
+      headers: { "x-secret": config.hemocioneIdFactsSecret },
+      timeout: 5000,
+    });
+  } catch (error) {
+    console.error("[gamification] failed to push fact to hemocione-id", error);
+  }
+}

--- a/server/services/likeService.test.ts
+++ b/server/services/likeService.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => {
+  const likes = {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+  };
+  const competitionTeams = {
+    update: vi.fn(),
+  };
+  const dbClient: { likes: typeof likes; competitionTeams: typeof competitionTeams; $transaction: ReturnType<typeof vi.fn> } = {
+    likes,
+    competitionTeams,
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback(dbClient)
+    ),
+  };
+  return { dbClient, likes, competitionTeams };
+});
+
+vi.mock("../db", () => ({ dbClient: db.dbClient }));
+
+import { likeTeam } from "./likeService";
+
+describe("likeTeam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.likes.create.mockResolvedValue({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+    db.competitionTeams.update.mockResolvedValue({});
+  });
+
+  it("creates the like and increments amountLikes", async () => {
+    db.likes.findUnique.mockResolvedValue(null);
+
+    const result = await likeTeam({
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    expect(result).toEqual({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+    expect(db.likes.create).toHaveBeenCalledWith({
+      data: { hemocioneID: "user-1", competitionTeamId: 10 },
+    });
+    expect(db.competitionTeams.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: { amountLikes: { increment: 1 } },
+    });
+  });
+
+  it("returns null and does not increment twice when already liked", async () => {
+    db.likes.findUnique.mockResolvedValue({
+      id: 1,
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    const result = await likeTeam({
+      hemocioneID: "user-1",
+      competitionTeamId: 10,
+    });
+
+    expect(result).toBeNull();
+    expect(db.likes.create).not.toHaveBeenCalled();
+    expect(db.competitionTeams.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/likeService.ts
+++ b/server/services/likeService.ts
@@ -1,0 +1,43 @@
+import { dbClient } from "../db";
+
+export const likeTeam = async (data: {
+  hemocioneID: string;
+  competitionTeamId: number;
+}) => {
+  const { hemocioneID, competitionTeamId } = data;
+
+  return await dbClient.$transaction(async (db) => {
+    const existingLike = await db.likes.findUnique({
+      where: {
+        likes_hemocioneID_competitionTeamId: {
+          hemocioneID,
+          competitionTeamId,
+        },
+      },
+    });
+
+    if (existingLike) {
+      return null;
+    }
+
+    const like = await db.likes.create({
+      data: {
+        hemocioneID,
+        competitionTeamId,
+      },
+    });
+
+    await db.competitionTeams.update({
+      where: {
+        id: competitionTeamId,
+      },
+      data: {
+        amountLikes: {
+          increment: 1,
+        },
+      },
+    });
+
+    return like;
+  });
+};

--- a/server/services/pickWinningTeam.test.ts
+++ b/server/services/pickWinningTeam.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { pickWinningTeam } from "./pickWinningTeam";
+
+describe("pickWinningTeam", () => {
+  it("returns the team with the highest donation_count", () => {
+    const ranking = [
+      { teamId: 1, donation_count: 3 },
+      { teamId: 2, donation_count: 10 },
+      { teamId: 3, donation_count: 7 },
+    ];
+    expect(pickWinningTeam(ranking)?.teamId).toBe(2);
+  });
+
+  it("returns null when there is no ranking data", () => {
+    expect(pickWinningTeam([])).toBeNull();
+  });
+
+  it("returns null when every team has zero or null donation_count", () => {
+    const ranking = [
+      { teamId: 1, donation_count: 0 },
+      { teamId: 2, donation_count: null },
+    ];
+    expect(pickWinningTeam(ranking)).toBeNull();
+  });
+});

--- a/server/services/pickWinningTeam.ts
+++ b/server/services/pickWinningTeam.ts
@@ -1,0 +1,12 @@
+export const pickWinningTeam = (
+  ranking: Array<{ teamId: number; donation_count: number | null }>
+): { teamId: number; donation_count: number | null } | null => {
+  if (ranking.length === 0) return null;
+
+  const sorted = [...ranking].sort(
+    (a, b) => (b.donation_count ?? 0) - (a.donation_count ?? 0)
+  );
+  if ((sorted[0].donation_count ?? 0) === 0) return null;
+
+  return sorted[0];
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Objetivo

Promover o conteúdo atual de `develop` para `main`.

Inclui:
- contagem apenas de doações aprovadas;
- endpoint de likes de times;
- reconciliação e publicação de fatos de gamificação no backend.

## Validação local

- `yarn test` — 6 arquivos, 41 testes passando.
- `yarn build` — compilação de client, server e Nitro concluída; o clone local não tinha `BUGSNAG_API_KEY`, então apenas o upload de sourcemaps foi interrompido no final.
